### PR TITLE
[FEAT] 패턴 CRUD 기능 구현 #3

### DIFF
--- a/src/main/generated/com/synergyx/trading/model/QPatternEntity.java
+++ b/src/main/generated/com/synergyx/trading/model/QPatternEntity.java
@@ -1,0 +1,58 @@
+package com.synergyx.trading.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPatternEntity is a Querydsl query type for PatternEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPatternEntity extends EntityPathBase<PatternEntity> {
+
+    private static final long serialVersionUID = 839707953L;
+
+    public static final QPatternEntity patternEntity = new QPatternEntity("patternEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath patternName = createString("patternName");
+
+    public final EnumPath<PeriodUnit> periodUnit = createEnum("periodUnit", PeriodUnit.class);
+
+    public final NumberPath<Integer> periodValue = createNumber("periodValue", Integer.class);
+
+    public final ListPath<Double, NumberPath<Double>> points = this.<Double, NumberPath<Double>>createList("points", Double.class, NumberPath.class, PathInits.DIRECT2);
+
+    public final StringPath stockId = createString("stockId");
+
+    public final StringPath symbol = createString("symbol");
+
+    public final NumberPath<Double> tolerance = createNumber("tolerance", Double.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public final StringPath userId = createString("userId");
+
+    public QPatternEntity(String variable) {
+        super(PatternEntity.class, forVariable(variable));
+    }
+
+    public QPatternEntity(Path<? extends PatternEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QPatternEntity(PathMetadata metadata) {
+        super(PatternEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/synergyx/trading/TradingApplication.java
+++ b/src/main/java/com/synergyx/trading/TradingApplication.java
@@ -2,7 +2,9 @@ package com.synergyx.trading;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class TradingApplication {
 

--- a/src/main/java/com/synergyx/trading/controller/PatternController.java
+++ b/src/main/java/com/synergyx/trading/controller/PatternController.java
@@ -1,0 +1,64 @@
+package com.synergyx.trading.controller;
+
+import com.synergyx.trading.dto.pattern.PatternRequestDTO;
+import com.synergyx.trading.dto.pattern.PatternResponseDTO;
+import com.synergyx.trading.service.patternService.PatternService;
+import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
+import com.synergyx.trading.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/patterns")
+public class PatternController {
+
+    private final PatternService patternService;
+
+    // 패턴 등록 (임시 유저 아이디)
+    @PostMapping
+    public ApiResponse<PatternResponseDTO.PatternDTO> createPattern(
+            @RequestBody @Valid PatternRequestDTO dto) {
+        String userId = "SoominCho";  // 임시 유저 아이디 (나중에 사용자 인증 대체 예정)
+        PatternResponseDTO.PatternDTO createdPattern = patternService.createPattern(userId, dto);
+        return ApiResponse.of(SuccessStatus._OK, createdPattern);
+    }
+
+    // 패턴 목록 조회 (임시 유저 아이디)
+    @GetMapping
+    public ApiResponse<List<PatternResponseDTO.PatternDTO>> getPatternList() {
+        String userId = "SoominCho"; // 임시 유저 아이디 (나중에 사용자 인증 대체 예정)
+        List<PatternResponseDTO.PatternDTO> list = patternService.getPatternList(userId);
+        return ApiResponse.of(SuccessStatus._OK, list);
+    }
+
+    // 패턴 상세 조회 (임시 유저 아이디)
+    @GetMapping("/{patternId}")
+    public ApiResponse<PatternResponseDTO.PatternDetailDTO> getPatternDetail(@PathVariable Long patternId) {
+        String userId = "SoominCho"; // JWT 적용 전까지 고정
+        PatternResponseDTO.PatternDetailDTO dto = patternService.getPatternDetail(patternId, userId);
+        return ApiResponse.of(SuccessStatus._OK, dto);
+    }
+
+    // 패턴 수정 (임시 유저 아이디)
+    @PatchMapping("/{patternId}")
+    public ApiResponse<Void> updatePattern(@PathVariable Long patternId,
+                                           @RequestBody PatternRequestDTO dto) {
+        String userId = "SoominCho";
+        patternService.updatePattern(patternId, userId, dto);
+        return ApiResponse.of(SuccessStatus._OK, null);
+    }
+
+    // 패턴 삭제 (임시 유저 아이디)
+    @DeleteMapping("/{patternId}")
+    public ApiResponse<Void> deletePattern(@PathVariable Long patternId) {
+        String userId = "SoominCho";
+        patternService.deletePattern(patternId, userId);
+        return ApiResponse.of(SuccessStatus._OK, null);
+    }
+
+}
+

--- a/src/main/java/com/synergyx/trading/conveter/PatternPointsConverter.java
+++ b/src/main/java/com/synergyx/trading/conveter/PatternPointsConverter.java
@@ -1,0 +1,43 @@
+package com.synergyx.trading.conveter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Converter
+public class PatternPointsConverter implements AttributeConverter<List<Double>, String> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    // 엔티티 List<Double> → JSON 문자열(String) 변환 메서드
+    // ex) → {0.0, 2.5, 3.1} -> "[0.0, 2.5, 3.1]"
+    // JPA가 엔티티를 저장할 때 자동으로 호출
+    // 리스트를 문자열로 직렬화해 DB에 저장
+    // 파싱 실패 시 빈 리스트 반환
+    @Override
+    public String convertToDatabaseColumn(List<Double> attribute) {
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (Exception e) {
+            return "[]";
+        }
+    }
+
+    // DB에 저장된 JSON 좌표를 List<Double>로 파싱하는 메서드
+    // 패턴 좌표는 DB에 JSON 형태로 저장
+    // ex) "[0.0, 2.5, 3.1]" → {0.0, 2.5, 3.1}
+    // 파싱 실패 시 빈 리스트 반환
+    @Override
+    public List<Double> convertToEntityAttribute(String dbData) {
+        try {
+            return mapper.readValue(dbData, new TypeReference<List<Double>>() {});
+        } catch (Exception e) {
+            return new ArrayList<>();
+        }
+    }
+}
+

--- a/src/main/java/com/synergyx/trading/dto/pattern/PatternRequestDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/pattern/PatternRequestDTO.java
@@ -1,0 +1,21 @@
+package com.synergyx.trading.dto.pattern;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PatternRequestDTO {
+    private String patternName; // 패턴 이름
+//    private String symbol; // 종목 코드
+    private List<Double> points; // 좌표
+    private Double tolerance; // 오차 범위
+    private Integer periodValue; // 기간 수치
+    private String periodUnit; // 기간 단위
+}

--- a/src/main/java/com/synergyx/trading/dto/pattern/PatternResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/pattern/PatternResponseDTO.java
@@ -1,0 +1,63 @@
+package com.synergyx.trading.dto.pattern;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+public class PatternResponseDTO {
+    // 패턴 목록 조회
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PatternDTO {
+        private Long patternId; // 패턴 아이디
+        private String patternName; // 패턴 이름
+        private List<Double> points; // 좌표
+    }
+    // 패턴 상세 조회
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PatternDetailDTO {
+        private Long patternId; // 패턴 아이디
+        private String patternName; // 패턴 이름
+        private List<Double> points; // 좌표
+        private Double tolerance; // 오차 범위
+        private Integer periodValue; // 기간 수치
+        private String periodUnit; // 기간 단위
+        private BacktestResultDTO backtestResult; // 최근 백테스트 결과
+        private List<AppliedStockDTO> appliedStockList; // 패턴 적용 종목 리스트
+    }
+    // 백테스트 결과
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BacktestResultDTO {
+        private Long backtestId; // 백테스팅 아이디
+        private String symbol; // 종목 코드
+        private String stockName; // 종목 이름
+        private String stockImage; // 종목 이미지
+        private String executedAt; // 백테스팅 실행 날짜
+        private Double winRate; // 승률
+        private Double averageReturn; // 평균 수익률
+        private Integer matchedCount; // 패턴 매칭 횟수
+    }
+
+    // 패턴 적용된 종목 리스트
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AppliedStockDTO {
+        private String symbol; // 종목 코드
+        private String stockName; // 종목 이름
+        private String stockImage; // 종목 이미지
+    }
+}
+
+

--- a/src/main/java/com/synergyx/trading/model/PatternEntity.java
+++ b/src/main/java/com/synergyx/trading/model/PatternEntity.java
@@ -1,0 +1,55 @@
+package com.synergyx.trading.model;
+
+import com.synergyx.trading.conveter.PatternPointsConverter;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "pattern")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PatternEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String patternName; // 패턴 이름
+
+    @Convert(converter = PatternPointsConverter.class)
+    @Lob
+    private List<Double> points; // 좌표
+
+    private Double tolerance; // 오차 범위
+    private Integer periodValue; // 기간 수치
+
+    @Enumerated(EnumType.STRING)
+    private PeriodUnit periodUnit; // 기간 단위
+
+    @CreatedDate
+    private LocalDateTime createdAt; // 생성 일시
+    @LastModifiedDate
+    private LocalDateTime updatedAt; // 수정 일시
+
+    //    임시 데이터 -> 나중에 종목/유저 엔티티 생성 후 수정
+    private String symbol; // 종목 심볼
+    private String stockId; // 종목 아이디
+    private String userId; // 사용자 아이디
+
+//    // 종목 테이블 매핑
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "stockId")
+//    private StockEntity stock;
+
+//    // 사용자 테이블 매핑
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "userId")
+//    private UserEntity user;
+}
+

--- a/src/main/java/com/synergyx/trading/model/PeriodUnit.java
+++ b/src/main/java/com/synergyx/trading/model/PeriodUnit.java
@@ -1,0 +1,5 @@
+package com.synergyx.trading.model;
+
+public enum PeriodUnit {
+    SEC, MINUTE, HOUR, DAY, MONTH;
+}

--- a/src/main/java/com/synergyx/trading/repository/PatternRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/PatternRepository.java
@@ -1,0 +1,16 @@
+package com.synergyx.trading.repository;
+
+import com.synergyx.trading.model.PatternEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PatternRepository extends JpaRepository<PatternEntity, String> {
+    // 임시 유저
+    List<PatternEntity> findByUserId(String userId);
+
+    Optional<PatternEntity> findById(Long id);
+}

--- a/src/main/java/com/synergyx/trading/service/patternService/PatternService.java
+++ b/src/main/java/com/synergyx/trading/service/patternService/PatternService.java
@@ -1,0 +1,23 @@
+package com.synergyx.trading.service.patternService;
+
+import com.synergyx.trading.dto.pattern.PatternRequestDTO;
+import com.synergyx.trading.dto.pattern.PatternResponseDTO;
+
+import java.util.List;
+
+public interface PatternService {
+    // 패턴 생성 (임시 유저)
+    PatternResponseDTO.PatternDTO createPattern(String userId, PatternRequestDTO dto);
+
+    // 패턴 목록 조회 (임시 유저)
+    List<PatternResponseDTO.PatternDTO> getPatternList(String userId);
+
+    // 패턴 상세 조회 (임시 유저)
+    PatternResponseDTO.PatternDetailDTO getPatternDetail(Long patternId, String userId);
+
+    // 패턴 수정 (임시 유저)
+    void updatePattern(Long patternId, String userId, PatternRequestDTO dto);
+
+    // 패턴 삭제 (임시 유저)
+    void deletePattern(Long patternId, String userId);
+}

--- a/src/main/java/com/synergyx/trading/service/patternService/PatternServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternService/PatternServiceImpl.java
@@ -1,0 +1,116 @@
+package com.synergyx.trading.service.patternService;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.synergyx.trading.dto.pattern.PatternRequestDTO;
+import com.synergyx.trading.dto.pattern.PatternResponseDTO;
+import com.synergyx.trading.model.PatternEntity;
+import com.synergyx.trading.model.PeriodUnit;
+import com.synergyx.trading.repository.PatternRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PatternServiceImpl implements PatternService {
+
+    private final PatternRepository patternRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 패턴 생성 (임시 유저 아이디)
+    @Override
+    public PatternResponseDTO.PatternDTO createPattern(String userId, PatternRequestDTO dto) {
+        String pointsJson;
+        try {
+            pointsJson = objectMapper.writeValueAsString(dto.getPoints());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("points 변환 실패", e);
+        }
+
+        PatternEntity patternEntity = PatternEntity.builder()
+                .patternName(dto.getPatternName())
+                .points(dto.getPoints())
+//                .symbol(dto.getSymbol())
+                .tolerance(dto.getTolerance())
+                .periodValue(dto.getPeriodValue())
+                .periodUnit(PeriodUnit.valueOf(dto.getPeriodUnit().toUpperCase()))
+                .userId(userId) // 임시 유저 아이디
+                .build();
+
+        PatternEntity savedPattern = patternRepository.save(patternEntity);
+
+        return PatternResponseDTO.PatternDTO.builder()
+                .patternId(savedPattern.getId())
+                .patternName(savedPattern.getPatternName())
+                .points(dto.getPoints())
+                .build();
+    }
+
+    // 패턴 목록 조회 (임시 유저 아이디)
+    @Override
+    public List<PatternResponseDTO.PatternDTO> getPatternList(String userId) {
+        return patternRepository.findByUserId(userId).stream()
+                .map(entity -> new PatternResponseDTO.PatternDTO(
+                        entity.getId(),
+                        entity.getPatternName(),
+                        entity.getPoints()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    // 패턴 상세 조회 (임시 유저 아이디)
+    @Override
+    public PatternResponseDTO.PatternDetailDTO getPatternDetail(Long patternId, String userId) {
+        PatternEntity entity = patternRepository.findById(patternId)
+                .orElseThrow(() -> new NoSuchElementException("패턴이 없습니다"));
+
+        return new PatternResponseDTO.PatternDetailDTO(
+                entity.getId(),
+                entity.getPatternName(),
+                entity.getPoints(),
+                entity.getTolerance(),
+                entity.getPeriodValue(),
+                entity.getPeriodUnit().name(),
+
+                // 임시 목데이터
+                new PatternResponseDTO.BacktestResultDTO(102L, "NFLX", "Netflix, Inc", "imageurl", "2024-04-25", 58.0, 9.7, 5),
+
+                // 임시 목데이터
+                Arrays.asList(
+                        new PatternResponseDTO.AppliedStockDTO("NFLX", "Netflix, Inc", "imageurl"),
+                        new PatternResponseDTO.AppliedStockDTO("AAPL", "Apple, Inc", "imageurl")
+                )
+        );
+    }
+
+    // 패턴 수정 (임시 유저 아이디)
+    @Override
+    public void updatePattern(Long patternId, String userId, PatternRequestDTO dto) {
+        PatternEntity entity = patternRepository.findById(patternId)
+                .orElseThrow(() -> new NoSuchElementException("패턴이 존재하지 않습니다."));
+
+        entity.setPatternName(dto.getPatternName());
+        entity.setPoints(dto.getPoints());
+        entity.setTolerance(dto.getTolerance());
+        entity.setPeriodValue(dto.getPeriodValue());
+        entity.setPeriodUnit(PeriodUnit.valueOf(dto.getPeriodUnit().toUpperCase()));
+        entity.setUpdatedAt(LocalDateTime.now());
+
+        patternRepository.save(entity);
+    }
+
+    // 패턴 삭제
+    @Override
+    public void deletePattern(Long patternId, String userId) {
+        PatternEntity entity = patternRepository.findById(patternId)
+                .orElseThrow(() -> new NoSuchElementException("패턴이 존재하지 않습니다."));
+        patternRepository.delete(entity);
+    }
+
+}


### PR DESCRIPTION
## 🚀 개요
차트 패턴 CRUD 기능 구현

## 📌 관련 이슈
- #3 

## ⏳ 작업 내용
- 패턴 엔티티 및 DTO 생성
- 패턴 생성 기능 구현
- 패턴 목록 조회 기능 구현
- 패턴 상세 조회 기능 구현
- 패턴 수정 기능 구현
- 패턴 삭제 기능 구현

## 📸 스크린샷
- 패턴 생성
![스크린샷 2025-05-18 193500](https://github.com/user-attachments/assets/b71636a5-f280-4eb9-a673-f5b7dc9041fd)
- 패턴 목록 조회
![스크린샷 2025-05-18 200248](https://github.com/user-attachments/assets/c26dd55c-e611-4160-9435-7d8fc0054812)
- 패턴 상세 조회
![스크린샷 2025-05-18 212616](https://github.com/user-attachments/assets/1d0fcf2a-9e8d-4252-8f72-7d208fc8fa6b)
- 패턴 수정
![스크린샷 2025-05-18 205023](https://github.com/user-attachments/assets/1f7ded33-6119-4b23-828f-0632af4da133)
- 패턴 삭제
![스크린샷 2025-05-18 205120](https://github.com/user-attachments/assets/9c23a6f6-3443-4a98-8f45-163a2c17c73c)

## 📝 참고 사항
- 일단 사용자 부분 구현 전이므로 임시 데이터로 설정해뒀습니다.
- 백테스팅 및 적용된 종목 리스트 임시 목데이터로 처리 했습니다.