### PR TITLE
[FEAT] 백테스팅 API 기능 구현 #5

### DIFF
--- a/src/main/java/com/synergyx/trading/controller/BacktestController.java
+++ b/src/main/java/com/synergyx/trading/controller/BacktestController.java
@@ -7,10 +7,7 @@ import com.synergyx.trading.dto.backtest.BacktestResponseDTO;
 import com.synergyx.trading.service.backtestService.BacktestService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
-
-import java.awt.print.Pageable;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/synergyx/trading/controller/BacktestController.java
+++ b/src/main/java/com/synergyx/trading/controller/BacktestController.java
@@ -1,0 +1,58 @@
+package com.synergyx.trading.controller;
+
+import com.synergyx.trading.apiPayload.ApiResponse;
+import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
+import com.synergyx.trading.dto.backtest.BacktestRequestDTO;
+import com.synergyx.trading.dto.backtest.BacktestResponseDTO;
+import com.synergyx.trading.service.backtestService.BacktestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+import java.awt.print.Pageable;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/backtests")
+public class BacktestController {
+    private final BacktestService backtestService;
+
+    // 백테스트 실행
+    @PostMapping
+    public ApiResponse<BacktestResponseDTO.BacktestExecutionDTO> runBacktest(
+            @RequestParam Long patternId,
+            @RequestParam(defaultValue = "1") Long stockId, // 종목 엔티티 생성 전 하드코딩 -> 구현 후 수정
+            @RequestBody BacktestRequestDTO request) {
+        BacktestResponseDTO.BacktestExecutionDTO result = backtestService.runBacktest(patternId, stockId, request);
+        return ApiResponse.of(SuccessStatus._OK, result);
+    }
+
+    // 과거 백테스팅 결과 상세 조회
+    @GetMapping("/results/{backtestId}")
+    public ApiResponse<BacktestResponseDTO.BacktestResultDetailDTO> getBacktestResultDetail(@PathVariable Long backtestId) {
+        BacktestResponseDTO.BacktestResultDetailDTO dto = backtestService.getBacktestResultDetail(backtestId);
+        return ApiResponse.of(SuccessStatus._OK, dto);
+    }
+
+    // 최근 백테스팅 결과 목록 조회
+    @GetMapping("/results")
+    public ApiResponse<BacktestResponseDTO.BacktestResultListDTO> getBacktestResultList(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Page<BacktestResponseDTO.BacktestSummaryDTO> resultPage = backtestService.getBacktestResultList(page - 1, size);
+
+        BacktestResponseDTO.BacktestResultListDTO dto = BacktestResponseDTO.BacktestResultListDTO.builder()
+                .content(resultPage.getContent())
+                .pageInfo(BacktestResponseDTO.BacktestResultListDTO.PageInfoDTO.builder()
+                        .page(resultPage.getNumber() + 1)
+                        .size(resultPage.getSize())
+                        .totalElements(resultPage.getTotalElements())
+                        .totalPages(resultPage.getTotalPages())
+                        .build())
+                .build();
+
+        return ApiResponse.of(SuccessStatus._OK, dto);
+    }
+}

--- a/src/main/java/com/synergyx/trading/dto/backtest/BacktestRequestDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/backtest/BacktestRequestDTO.java
@@ -1,0 +1,20 @@
+package com.synergyx.trading.dto.backtest;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+// 백테스팅 실행 날짜 조건
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BacktestRequestDTO {
+    // JSON 문자열 -> LocalDate 타입 형변환
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate startDate; // 백테스트 시작일
+    private LocalDate endDate; // 백테스트 종료일
+}

--- a/src/main/java/com/synergyx/trading/dto/backtest/BacktestResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/backtest/BacktestResponseDTO.java
@@ -1,0 +1,90 @@
+package com.synergyx.trading.dto.backtest;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+import java.util.List;
+
+public class BacktestResponseDTO  {
+    // 백테스트 실행
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BacktestExecutionDTO {
+        private String stockName; // 종목명
+        private LocalDate executedAt; // 백테스트 실행 날짜
+        private Integer matchedCount; // 패턴 매칭 횟수
+        private LocalDate startDate; // 백테스트 시작일
+        private LocalDate endDate; // 백테스트 종료일
+        private Double winRate; // 승률
+        private Double averageReturn; // 평균 수익률
+        private Double maxReturn; // 최대 수익률
+        private LocalDate maxReturnDate; // 최대 수익률 발생일
+        private Double minReturn; // 최대 손실률
+        private LocalDate minReturnDate; // 최대 손실률 발생일
+        private Double totalReturn; // 모든 매칭 결과 누적 수익률
+        private LocalDate lastMatchedDate; // 마지막 패턴 발생일
+        private Double lastMatchedReturn; // 마지막 패턴 발생시 수익률
+    }
+    // 백테스팅 결과 상세 조회
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BacktestResultDetailDTO {
+        private String stockName; // 종목명
+        private String stockImage; // 종목 이미지
+        private LocalDate executedAt; // 백테스트 실행 날짜
+        private Integer matchedCount; // 패턴 매칭 횟수
+        private LocalDate startDate; // 백테스트 시작일
+        private LocalDate endDate; // 백테스트 종료일
+        private Double winRate; // 승률
+        private Double averageReturn; // 평균 수익률
+        private Double maxReturn; // 최대 수익률
+        private LocalDate maxReturnDate; // 최대 수익률 발생일
+        private Double minReturn; // 최대 손실률
+        private LocalDate minReturnDate; // 최대 손실률 발생일
+        private Double totalReturn; // 모든 매칭 결과 누적 수익률
+        private LocalDate lastMatchedDate; // 마지막 패턴 발생일
+        private Double lastMatchedReturn; // 마지막 패턴 발생시 수익률
+    }
+
+    // 백테스팅 결과 목록 조회용 content
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BacktestSummaryDTO {
+        private Long backtestId; // 백테스트 ID
+        private String stockName; // 종목명
+        private LocalDate executedAt; // 실행 날짜
+        private Double winRate; // 승률
+        private Double averageReturn; // 평균 수익률
+        private Integer matchedCount; // 패턴 매칭 횟수
+    }
+
+    // 백테스팅 결과 목록 조회
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BacktestResultListDTO {
+        private List<BacktestSummaryDTO> content; // 백테스팅 결과 요약
+        private PageInfoDTO pageInfo; // 페이지 정보
+
+        // 페이지 정보
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class PageInfoDTO {
+            private int page; // 현재 페이지 번호
+            private int size; // 한 페이지 당 데이터 개수
+            private long totalElements; // 전체 데이터 개수
+            private int totalPages; // 전체 페이지 수
+        }
+    }
+
+}

--- a/src/main/java/com/synergyx/trading/dto/pattern/PatternRequestDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/pattern/PatternRequestDTO.java
@@ -7,13 +7,13 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+// 패턴 생성, 수정
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class PatternRequestDTO {
     private String patternName; // 패턴 이름
-//    private String symbol; // 종목 코드
     private List<Double> points; // 좌표
     private Double tolerance; // 오차 범위
     private Integer periodValue; // 기간 수치

--- a/src/main/java/com/synergyx/trading/dto/pattern/PatternResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/pattern/PatternResponseDTO.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 import java.util.List;
 
 public class PatternResponseDTO {
@@ -42,10 +44,14 @@ public class PatternResponseDTO {
         private String symbol; // 종목 코드
         private String stockName; // 종목 이름
         private String stockImage; // 종목 이미지
-        private String executedAt; // 백테스팅 실행 날짜
+        private LocalDate executedAt; // 백테스팅 실행 날짜
+        private Integer matchedCount; // 패턴 매칭 횟수
+        private LocalDate startDate; // 백테스트 시작일
+        private LocalDate endDate; // 백테스트 종료일
         private Double winRate; // 승률
         private Double averageReturn; // 평균 수익률
-        private Integer matchedCount; // 패턴 매칭 횟수
+        private Double maxReturn; // 최대 수익률
+        private LocalDate maxReturnDate; // 최대 수익률 발생일
     }
 
     // 패턴 적용된 종목 리스트

--- a/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyRequestDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyRequestDTO.java
@@ -1,0 +1,17 @@
+package com.synergyx.trading.dto.patternApply;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+// 패턴 적용
+public class PatternApplyRequestDTO {
+    private Long patternId;
+    private Long stockId;
+}
+

--- a/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyResponseDTO.java
@@ -1,0 +1,21 @@
+package com.synergyx.trading.dto.patternApply;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class PatternApplyResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    // 패턴 상세 화면 -> 적용된 패턴 목록
+    public static class PatternApplyDTO {
+        private Long applyId;
+        private String patternName;
+        private String stockSymbol;
+        private String stockName;
+    }
+}
+

--- a/src/main/java/com/synergyx/trading/model/BacktestEntity.java
+++ b/src/main/java/com/synergyx/trading/model/BacktestEntity.java
@@ -1,0 +1,47 @@
+package com.synergyx.trading.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "backtest")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BacktestEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 패턴 테이블 매핑
+    @ManyToOne
+    @JoinColumn(name = "pattern_id", nullable = false)
+    private PatternEntity pattern;
+
+    // 임시 데이터 -> 종목 엔티티 생성 후 수정
+    @Column(name = "stock_id")
+    private Long stockId; // 종목 아이디
+
+    // 종목 엔티티 구현 후 캡션 제거
+    // 종목 테이블 매핑
+//    @ManyToOne
+//    @JoinColumn(name = "stock_id", nullable = false)
+//    private StockEntity stock;
+
+    private LocalDate executedAt; // 백테스트 실행 날짜
+    private Integer matchedCount; // 패턴 매칭 횟수
+    private LocalDate startDate; // 백테스트 시작일
+    private LocalDate endDate; // 백테스트 종료일
+    private Double winRate; // 승률
+    private Double averageReturn; // 평균 수익률
+    private Double maxReturn; // 최대 수익률
+    private LocalDate maxReturnDate; // 최대 수익률 발생일
+    private Double minReturn; // 최대 손실률
+    private LocalDate minReturnDate; // 최대 손실률 발생일
+    private Double totalReturn; // 모든 매칭 결과 누적 수익률
+    private LocalDate lastMatchedDate; // 마지막 패턴 발생일
+    private Double lastMatchedReturn; // 마지막 패턴 발생시 수익률
+}

--- a/src/main/java/com/synergyx/trading/model/PatternApplyEntity.java
+++ b/src/main/java/com/synergyx/trading/model/PatternApplyEntity.java
@@ -1,0 +1,40 @@
+package com.synergyx.trading.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "pattern_apply")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PatternApplyEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 패턴 테이블 매핑
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pattern_id")
+    private PatternEntity pattern;
+
+    // 백테스팅 테이블 일대다 매핑
+//    @OneToMany(mappedBy = "patternApply")
+//    private List<BacktestEntity> backtestResults;
+
+    // 임시 데이터 -> 종목 엔티티 생성 후 수정
+    @Column(name = "stock_id")
+    private String stockId;
+
+    // 종목 테이블 매핑
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "stock_id")
+//    private StockEntity stock;
+
+}
+

--- a/src/main/java/com/synergyx/trading/model/PatternApplyEntity.java
+++ b/src/main/java/com/synergyx/trading/model/PatternApplyEntity.java
@@ -3,8 +3,6 @@ package com.synergyx.trading.model;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.List;
-
 @Entity
 @Table(name = "pattern_apply")
 @Getter

--- a/src/main/java/com/synergyx/trading/model/PatternEntity.java
+++ b/src/main/java/com/synergyx/trading/model/PatternEntity.java
@@ -37,19 +37,17 @@ public class PatternEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt; // 수정 일시
 
-    //    임시 데이터 -> 나중에 종목/유저 엔티티 생성 후 수정
-    private String symbol; // 종목 심볼
-    private String stockId; // 종목 아이디
+    // 적용된 종목 목록 (중간 엔티티 통해)
+    @OneToMany(mappedBy = "pattern")
+    private List<PatternApplyEntity> patternApplies;
+
+    // 임시 데이터 -> 유저 엔티티 생성 후 수정
+    @Column(name = "user_id")
     private String userId; // 사용자 아이디
 
-//    // 종목 테이블 매핑
+    // 사용자 테이블 매핑
 //    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "stockId")
-//    private StockEntity stock;
-
-//    // 사용자 테이블 매핑
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "userId")
+//    @JoinColumn(name = "user_id")
 //    private UserEntity user;
 }
 

--- a/src/main/java/com/synergyx/trading/repository/BacktestRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/BacktestRepository.java
@@ -1,0 +1,12 @@
+package com.synergyx.trading.repository;
+
+import com.synergyx.trading.model.BacktestEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface BacktestRepository extends JpaRepository<BacktestEntity, Long> {
+    // 패턴 별 백테스팅 결과 조회용
+    Optional<BacktestEntity> findTopByPatternIdOrderByExecutedAtDesc(Long patternId);
+}

--- a/src/main/java/com/synergyx/trading/repository/PatternApplyRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/PatternApplyRepository.java
@@ -1,0 +1,12 @@
+package com.synergyx.trading.repository;
+
+import com.synergyx.trading.model.PatternApplyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PatternApplyRepository extends JpaRepository<PatternApplyEntity, Long> {
+    List<PatternApplyEntity> findByPatternId(Long patternId);
+}

--- a/src/main/java/com/synergyx/trading/service/backtestService/BacktestService.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/BacktestService.java
@@ -1,0 +1,17 @@
+package com.synergyx.trading.service.backtestService;
+
+import com.synergyx.trading.dto.backtest.BacktestRequestDTO;
+import com.synergyx.trading.dto.backtest.BacktestResponseDTO;
+import org.springframework.data.domain.Page;
+
+public interface BacktestService {
+    // 백테스팅 실행
+    BacktestResponseDTO.BacktestExecutionDTO runBacktest(Long patternId, Long stockId, BacktestRequestDTO request);
+
+    // 백테스팅 결과 상세 조회
+    BacktestResponseDTO.BacktestResultDetailDTO getBacktestResultDetail(Long backtestId);
+
+    // 백테스팅 결과 목록 조회
+    Page<BacktestResponseDTO.BacktestSummaryDTO> getBacktestResultList(int page, int size);
+
+}

--- a/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
@@ -1,0 +1,130 @@
+package com.synergyx.trading.service.backtestService;
+import com.synergyx.trading.dto.backtest.BacktestRequestDTO;
+import com.synergyx.trading.dto.backtest.BacktestResponseDTO;
+import com.synergyx.trading.model.BacktestEntity;
+import com.synergyx.trading.model.PatternEntity;
+import com.synergyx.trading.repository.BacktestRepository;
+import com.synergyx.trading.repository.PatternRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class BacktestServiceImpl implements BacktestService {
+    private final PatternRepository patternRepository;
+    private final BacktestRepository backtestRepository;
+
+    // 백테스팅 실행
+    @Override
+    public BacktestResponseDTO.BacktestExecutionDTO runBacktest(Long patternId, Long stockId, BacktestRequestDTO request) {
+        PatternEntity pattern = patternRepository.findById(patternId)
+                .orElseThrow(() -> new IllegalArgumentException("패턴이 존재하지 않습니다."));
+        // 종목 엔티티 구현 전 -> 구현 후 캡션 제거
+//        StockEntity stock = stockRepository.findById(stockId)
+//                .orElseThrow(() -> new IllegalArgumentException("종목이 존재하지 않습니다."));
+
+        LocalDate startDate = request.getStartDate();
+        LocalDate endDate = request.getEndDate();
+
+        // 백테스팅 기간 최대 5년 제한
+        if (startDate.isAfter(endDate) || startDate.plusYears(5).isBefore(endDate)) {
+            throw new IllegalArgumentException("실행 기간은 최대 5년 입니다.");
+        }
+
+        // 백테스트 분석 로직 호출
+        // fastAPI 연결 후 수정.
+        // 분석 결과 (목데이터)
+        BacktestResponseDTO.BacktestExecutionDTO resultDto = BacktestResponseDTO.BacktestExecutionDTO.builder()
+                .stockName("카카오")  // 임시 종목명 -> 실제 연동 시 stockId로 조회 예정
+                .executedAt(LocalDate.now())
+                .startDate(startDate)
+                .endDate(endDate)
+                .winRate(65.2)
+                .averageReturn(12.5)
+                .matchedCount(8)
+                .maxReturnDate(LocalDate.of(2024, 3, 15))
+                .maxReturn(25.4)
+                .minReturnDate(LocalDate.of(2024, 2, 10))
+                .minReturn(-7.8)
+                .lastMatchedDate(LocalDate.of(2024, 4, 20))
+                .lastMatchedReturn(9.3)
+                .totalReturn(88.3)
+                .build();
+
+        // fastAPI 연결 후 수정.
+        // 분석 결과를 DB에 저장
+        BacktestEntity entity = BacktestEntity.builder()
+                .pattern(pattern)
+                .stockId(stockId)
+                .executedAt(resultDto.getExecutedAt())
+                .startDate(resultDto.getStartDate())
+                .endDate(resultDto.getEndDate())
+                .winRate(resultDto.getWinRate())
+                .averageReturn(resultDto.getAverageReturn())
+                .matchedCount(resultDto.getMatchedCount())
+                .maxReturnDate(resultDto.getMaxReturnDate())
+                .maxReturn(resultDto.getMaxReturn())
+                .minReturnDate(resultDto.getMinReturnDate())
+                .minReturn(resultDto.getMinReturn())
+                .lastMatchedDate(resultDto.getLastMatchedDate())
+                .lastMatchedReturn(resultDto.getLastMatchedReturn())
+                .totalReturn(resultDto.getTotalReturn())
+                .build();
+
+        backtestRepository.save(entity);
+
+        return resultDto;
+    }
+
+    // 과거 백테스팅 결과 상세 조회
+    @Override
+    public BacktestResponseDTO.BacktestResultDetailDTO getBacktestResultDetail(Long backtestId) {
+        BacktestEntity entity = backtestRepository.findById(backtestId)
+                .orElseThrow(() -> new NoSuchElementException("백테스팅 결과가 존재하지 않습니다."));
+
+        return BacktestResponseDTO.BacktestResultDetailDTO.builder()
+                .stockName("삼성전자") // 종목 엔티티 생성 전 하드코딩
+//                .stockName(entity.getStock().getStockName) // 종목 엔티티 생성 후 캡션 제거
+                .stockImage("imageurl") // 종목 엔티티 생성 전 하드코딩
+//                .stockImage(bt.getStock().getImageUrl()) // 종목 엔티티 생성 후 캡션 제거
+                .executedAt(entity.getExecutedAt())
+                .startDate(entity.getStartDate())
+                .endDate(entity.getEndDate())
+                .winRate(entity.getWinRate())
+                .averageReturn(entity.getAverageReturn())
+                .matchedCount(entity.getMatchedCount())
+                .maxReturnDate(entity.getMaxReturnDate())
+                .maxReturn(entity.getMaxReturn())
+                .minReturnDate(entity.getMinReturnDate())
+                .minReturn(entity.getMinReturn())
+                .lastMatchedDate(entity.getLastMatchedDate())
+                .lastMatchedReturn(entity.getLastMatchedReturn())
+                .totalReturn(entity.getTotalReturn())
+                .build();
+    }
+
+    // 백테스팅 결과 목록 조회
+    @Override
+    public Page<BacktestResponseDTO.BacktestSummaryDTO> getBacktestResultList(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("executedAt").descending());
+        Page<BacktestEntity> resultPage = backtestRepository.findAll(pageable);
+
+        return resultPage.map(entity -> BacktestResponseDTO.BacktestSummaryDTO.builder()
+                .backtestId(entity.getId())
+                .stockName("삼성전자") // 종목 엔티티 생성 전 하드코딩
+//                .stockName(entity.getStock().getStockName) // 종목 엔티티 생성 후 캡션 제거
+                .executedAt(entity.getExecutedAt())
+                .winRate(entity.getWinRate())
+                .averageReturn(entity.getAverageReturn())
+                .matchedCount(entity.getMatchedCount())
+                .build());
+    }
+
+}

--- a/src/main/java/com/synergyx/trading/service/patternService/PatternServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternService/PatternServiceImpl.java
@@ -87,6 +87,8 @@ public class PatternServiceImpl implements PatternService {
                 .maxReturnDate(bt.getMaxReturnDate())
                 .build()).orElse(null);
 
+        List<PatternApplyEntity> applyList = patternApplyRepository.findByPatternId(patternId);
+
         // 임시 목데이터 생성. -> 종목 엔티티 구현 후 코드 제거 예정
         List<PatternResponseDTO.AppliedStockDTO> appliedStocks = List.of(
                 PatternResponseDTO.AppliedStockDTO.builder()
@@ -102,7 +104,6 @@ public class PatternServiceImpl implements PatternService {
         );
 
 //        종목 엔티티 구현 후 캡션 제거
-//        List<PatternApplyEntity> applyList = patternApplyRepository.findByPatternId(patternId);
 //        List<PatternResponseDTO.AppliedStockDTO> appliedStocks = applyList.stream()
 //                .map(apply -> PatternResponseDTO.AppliedStockDTO.builder()
 //                        .symbol(apply.getStock().getSymbol())

--- a/src/main/java/com/synergyx/trading/service/patternService/PatternServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternService/PatternServiceImpl.java
@@ -1,19 +1,20 @@
 package com.synergyx.trading.service.patternService;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.synergyx.trading.dto.pattern.PatternRequestDTO;
 import com.synergyx.trading.dto.pattern.PatternResponseDTO;
+import com.synergyx.trading.model.BacktestEntity;
+import com.synergyx.trading.model.PatternApplyEntity;
 import com.synergyx.trading.model.PatternEntity;
 import com.synergyx.trading.model.PeriodUnit;
+import com.synergyx.trading.repository.BacktestRepository;
+import com.synergyx.trading.repository.PatternApplyRepository;
 import com.synergyx.trading.repository.PatternRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -21,26 +22,20 @@ import java.util.stream.Collectors;
 public class PatternServiceImpl implements PatternService {
 
     private final PatternRepository patternRepository;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final PatternApplyRepository patternApplyRepository;
+    private final BacktestRepository backtestRepository;
 
-    // 패턴 생성 (임시 유저 아이디)
+
+    // 패턴 생성 (임시 유저 아이디) -> 유저 엔티티 생성 후 수정 예정
     @Override
     public PatternResponseDTO.PatternDTO createPattern(String userId, PatternRequestDTO dto) {
-        String pointsJson;
-        try {
-            pointsJson = objectMapper.writeValueAsString(dto.getPoints());
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("points 변환 실패", e);
-        }
-
         PatternEntity patternEntity = PatternEntity.builder()
                 .patternName(dto.getPatternName())
                 .points(dto.getPoints())
-//                .symbol(dto.getSymbol())
                 .tolerance(dto.getTolerance())
                 .periodValue(dto.getPeriodValue())
                 .periodUnit(PeriodUnit.valueOf(dto.getPeriodUnit().toUpperCase()))
-                .userId(userId) // 임시 유저 아이디
+                .userId(userId) // 임시 유저 아이디 -> 유저 엔티티 생성 후 수정 예정
                 .build();
 
         PatternEntity savedPattern = patternRepository.save(patternEntity);
@@ -52,7 +47,7 @@ public class PatternServiceImpl implements PatternService {
                 .build();
     }
 
-    // 패턴 목록 조회 (임시 유저 아이디)
+    // 패턴 목록 조회 (임시 유저 아이디) -> 유저 엔티티 생성 후 수정 예정
     @Override
     public List<PatternResponseDTO.PatternDTO> getPatternList(String userId) {
         return patternRepository.findByUserId(userId).stream()
@@ -64,32 +59,72 @@ public class PatternServiceImpl implements PatternService {
                 .collect(Collectors.toList());
     }
 
-    // 패턴 상세 조회 (임시 유저 아이디)
+    // 패턴 상세 조회 (임시 유저 아이디) -> 유저 엔티티 생성 후 수정 예정
     @Override
     public PatternResponseDTO.PatternDetailDTO getPatternDetail(Long patternId, String userId) {
         PatternEntity entity = patternRepository.findById(patternId)
-                .orElseThrow(() -> new NoSuchElementException("패턴이 없습니다"));
+                .orElseThrow(() -> new NoSuchElementException("패턴이 존재하지 않습니다."));
 
-        return new PatternResponseDTO.PatternDetailDTO(
-                entity.getId(),
-                entity.getPatternName(),
-                entity.getPoints(),
-                entity.getTolerance(),
-                entity.getPeriodValue(),
-                entity.getPeriodUnit().name(),
+        // 백테스트 최근 결과
+        Optional<BacktestEntity> backtest = backtestRepository
+                .findTopByPatternIdOrderByExecutedAtDesc(patternId);
 
-                // 임시 목데이터
-                new PatternResponseDTO.BacktestResultDTO(102L, "NFLX", "Netflix, Inc", "imageurl", "2024-04-25", 58.0, 9.7, 5),
+        PatternResponseDTO.BacktestResultDTO backtestResult = backtest.map(bt -> PatternResponseDTO.BacktestResultDTO.builder()
+                .backtestId(bt.getId())
+                .symbol("NFLX") // 종목 엔티티 생성 전 하드코딩
+                .stockName("Netflix, Inc") // 종목 엔티티 생성 전 하드코딩
+                .stockImage("imageurl") // 종목 엔티티 생성 전 하드코딩
+//                .symbol(bt.getStock().getSymbol()) // 종목 엔티티 생성 후 캡션 제거
+//                .stockName(bt.getStock().getName()) // 종목 엔티티 생성 후 캡션 제거
+//                .stockImage(bt.getStock().getImageUrl()) // 종목 엔티티 생성 후 캡션 제거
+                .executedAt(bt.getExecutedAt())
+                .startDate(bt.getStartDate())
+                .endDate(bt.getEndDate())
+                .winRate(bt.getWinRate())
+                .averageReturn(bt.getAverageReturn())
+                .matchedCount(bt.getMatchedCount())
+                .maxReturn(bt.getMaxReturn())
+                .maxReturnDate(bt.getMaxReturnDate())
+                .build()).orElse(null);
 
-                // 임시 목데이터
-                Arrays.asList(
-                        new PatternResponseDTO.AppliedStockDTO("NFLX", "Netflix, Inc", "imageurl"),
-                        new PatternResponseDTO.AppliedStockDTO("AAPL", "Apple, Inc", "imageurl")
-                )
+        List<PatternApplyEntity> applyList = patternApplyRepository.findByPatternId(patternId);
+
+        // 임시 목데이터 생성. -> 종목 엔티티 구현 후 코드 제거 예정
+        List<PatternResponseDTO.AppliedStockDTO> appliedStocks = List.of(
+                PatternResponseDTO.AppliedStockDTO.builder()
+                        .symbol("NFLX")
+                        .stockName("Netflix, Inc")
+                        .stockImage("imageurl")
+                        .build(),
+                PatternResponseDTO.AppliedStockDTO.builder()
+                        .symbol("AAPL")
+                        .stockName("Apple, Inc")
+                        .stockImage("imageurl")
+                        .build()
         );
+
+//        종목 엔티티 구현 후 캡션 제거
+//        List<PatternResponseDTO.AppliedStockDTO> appliedStocks = applyList.stream()
+//                .map(apply -> PatternResponseDTO.AppliedStockDTO.builder()
+//                        .symbol(apply.getStock().getSymbol())
+//                        .stockName(apply.getStock().getName())
+//                        .stockImage(apply.getStock().getImageUrl())
+//                        .build())
+//                .toList();
+
+        return PatternResponseDTO.PatternDetailDTO.builder()
+                .patternId(entity.getId())
+                .patternName(entity.getPatternName())
+                .points(entity.getPoints())
+                .tolerance(entity.getTolerance())
+                .periodValue(entity.getPeriodValue())
+                .periodUnit(entity.getPeriodUnit().name())
+                .backtestResult(backtestResult)
+                .appliedStockList(appliedStocks)
+                .build();
     }
 
-    // 패턴 수정 (임시 유저 아이디)
+    // 패턴 수정 (임시 유저 아이디) -> 유저 엔티티 생성 후 수정 예정
     @Override
     public void updatePattern(Long patternId, String userId, PatternRequestDTO dto) {
         PatternEntity entity = patternRepository.findById(patternId)
@@ -105,7 +140,7 @@ public class PatternServiceImpl implements PatternService {
         patternRepository.save(entity);
     }
 
-    // 패턴 삭제
+    // 패턴 삭제 (임시 유저 아이디) -> 유저 엔티티 생성 후 수정 예정
     @Override
     public void deletePattern(Long patternId, String userId) {
         PatternEntity entity = patternRepository.findById(patternId)

--- a/src/main/java/com/synergyx/trading/service/patternService/PatternServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternService/PatternServiceImpl.java
@@ -87,8 +87,6 @@ public class PatternServiceImpl implements PatternService {
                 .maxReturnDate(bt.getMaxReturnDate())
                 .build()).orElse(null);
 
-        List<PatternApplyEntity> applyList = patternApplyRepository.findByPatternId(patternId);
-
         // 임시 목데이터 생성. -> 종목 엔티티 구현 후 코드 제거 예정
         List<PatternResponseDTO.AppliedStockDTO> appliedStocks = List.of(
                 PatternResponseDTO.AppliedStockDTO.builder()
@@ -104,6 +102,7 @@ public class PatternServiceImpl implements PatternService {
         );
 
 //        종목 엔티티 구현 후 캡션 제거
+//        List<PatternApplyEntity> applyList = patternApplyRepository.findByPatternId(patternId);
 //        List<PatternResponseDTO.AppliedStockDTO> appliedStocks = applyList.stream()
 //                .map(apply -> PatternResponseDTO.AppliedStockDTO.builder()
 //                        .symbol(apply.getStock().getSymbol())


### PR DESCRIPTION
## 🚀 개요
백테스팅 테이블 생성 및 API 기능 구현

## 📌 관련 이슈
- #5 

## ⏳ 작업 내용
- BacktestEntity 및 DTO 생성
- 백테스팅 실행 구현
- 백테스팅 결과 상세 조회 구현
- 백테스팅 결과 목록 조회 구현

## 📸 스크린샷
- ![스크린샷 2025-05-25 022547](https://github.com/user-attachments/assets/57437b65-4813-4686-9a11-8c6f0bcc757c)
- ![스크린샷 2025-05-25 023903](https://github.com/user-attachments/assets/eb34233b-5c1a-4f32-acc3-8d5602d2f579)
- ![스크린샷 2025-05-25 032440](https://github.com/user-attachments/assets/a3921d9c-fcf0-4358-8319-eb2fa5879316)

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- fastAPI 구현 전 백테스팅 결과값 목데이터로 입력 해뒀습니다.