### PR TITLE
[FIX] 패턴 상세 - 백테스팅 최근 1개 조회 조건 수정  #3

### DIFF
--- a/src/main/java/com/synergyx/trading/repository/BacktestRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/BacktestRepository.java
@@ -12,7 +12,9 @@ import java.util.Optional;
 @Repository
 public interface BacktestRepository extends JpaRepository<Backtest, Long> {
     // 패턴 별 백테스팅 결과 조회용 (최근 1개)
-    Optional<Backtest> findTopByUserIdAndPatternIdOrderByExecutedAtDesc(Long userId, Long patternId);
+    // 실행 날짜 동일할 경우, 아이디 내림차순.
+    Optional<Backtest> findTopByUserIdAndPatternIdOrderByExecutedAtDescIdDesc(Long userId, Long patternId);
+
     void deleteAllByPattern(Pattern pattern);
     Page<Backtest> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/synergyx/trading/service/patternService/PatternQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternService/PatternQueryServiceImpl.java
@@ -56,7 +56,7 @@ public class PatternQueryServiceImpl implements PatternQueryService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PATTERN_NOT_FOUND));
 
         // 백테스트 최근 결과
-        Optional<Backtest> backtest = backtestRepository.findTopByUserIdAndPatternIdOrderByExecutedAtDesc(userId, patternId);
+        Optional<Backtest> backtest = backtestRepository.findTopByUserIdAndPatternIdOrderByExecutedAtDescIdDesc(userId, patternId);
 
         PatternResponseDTO.BacktestResultDTO backtestResult = backtest.map(bt -> PatternResponseDTO.BacktestResultDTO.builder()
                 .backtestId(bt.getId())


### PR DESCRIPTION
## 🚀 개요
패턴 상세 화면에서 실행 날짜가 같을 경우 랜덤으로 1개가 표시되는 문제 해결
실행 날짜 비교 후 백테스팅 아이디 비교 -> 내림차순으로 1개 선택

## 📌 관련 이슈
#3

## ⏳ 작업 내용
- 백테스팅 최근 1개 조회 시 repository 조건 수정