### PR TITLE
[FEAT] 종목 검색, 종목 상세 조회 api 구현 #26

### DIFF
--- a/src/main/java/com/synergyx/trading/controller/StockController.java
+++ b/src/main/java/com/synergyx/trading/controller/StockController.java
@@ -1,0 +1,44 @@
+package com.synergyx.trading.controller;
+
+import com.synergyx.trading.apiPayload.ApiResponse;
+import com.synergyx.trading.dto.stockDetail.StockDetailResponseDTO;
+import com.synergyx.trading.dto.stockSearch.StockSearchResponseDTO;
+import com.synergyx.trading.service.stockDetailService.StockDetailQueryService;
+import com.synergyx.trading.service.stockSearchService.StockSearchQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/stocks")
+@Tag(name = "종목 상세 API", description = "종목 상세 관련 API 입니다.")
+public class StockController {
+
+    // 임시 userId
+    private static final Long TEMP_USER_ID = 1L;
+
+    private final StockSearchQueryService stockSearchQueryService;
+    private final StockDetailQueryService stockDetailQueryService;
+
+    @Operation(summary = "종목 상세 조회", description = "종목 상세 정보를 조회합니다.")
+    @GetMapping("/{stockId}/detail")
+    public ResponseEntity<?> getStockDetail(@PathVariable Long stockId) {
+        StockDetailResponseDTO dto = stockDetailQueryService.getStockDetail(stockId, TEMP_USER_ID);
+        return ResponseEntity.ok(ApiResponse.onSuccess(dto));
+    }
+
+    @Operation(summary = "종목 검색", description = "종목명을 기준으로 종목을 검색합니다.")
+    @GetMapping("/search")
+    public ResponseEntity<?> searchStocks(
+            @Parameter(description = "검색할 종목명 (예: 삼성, 하이닉스)")
+            @RequestParam String query) {
+        List<StockSearchResponseDTO> result = stockSearchQueryService.searchStocksByName(query);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+}

--- a/src/main/java/com/synergyx/trading/dto/stockDetail/StockDetailResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/stockDetail/StockDetailResponseDTO.java
@@ -1,0 +1,46 @@
+package com.synergyx.trading.dto.stockDetail;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StockDetailResponseDTO {
+    private String stockName;
+    private String price; //54,300
+    private String changeRate; // 1.12%
+    private String changeAmount; // 600
+    private Boolean isWatchlist;
+    private Boolean isTradeNotificationEnabled;
+    private PredictionDTO prediction;
+    private FinancialsDTO financials;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PredictionDTO {
+        private String upperBound; // 상한 예측 ex.63,000
+        private String lowerBound; // 하한 예측
+        private String buyPrice; // 적정 매수가
+        private String sellPrice; // 적정 매도가
+        private String targetRange; // 예측 범위
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class FinancialsDTO {
+        private String pbr;
+        private String per;
+        private String psr;
+        private String roe;
+        private String marketCap;
+        private String dividendYield;
+    }
+}

--- a/src/main/java/com/synergyx/trading/dto/stockSearch/StockSearchResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/stockSearch/StockSearchResponseDTO.java
@@ -1,0 +1,15 @@
+package com.synergyx.trading.dto.stockSearch;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StockSearchResponseDTO {
+
+    private Long id; // stock id
+    private String name;
+    private String imageUrl;
+}

--- a/src/main/java/com/synergyx/trading/repository/InterestStockRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/InterestStockRepository.java
@@ -10,7 +10,11 @@ import java.util.Optional;
 @Repository
 public interface InterestStockRepository extends JpaRepository<InterestStock, Long> {
     Optional<InterestStock> findByUserIdAndStockId(Long userId, Long stockId);
+
     List<InterestStock> findAllByUserId(Long userId);
+
     void deleteByUserIdAndStockId(Long userId, Long stockId);
+
+    boolean existsByUserIdAndStockId(Long userId, Long stockId);
 }
 

--- a/src/main/java/com/synergyx/trading/repository/StockDetailRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/StockDetailRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface StockDetailRepository extends JpaRepository<StockDetail, Long> {
     Optional<StockDetail> findByStock_Symbol(String symbol);
+
+    Optional<StockDetail> findByStock_Id(Long stockId);
 }

--- a/src/main/java/com/synergyx/trading/repository/StockRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/StockRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface StockRepository extends JpaRepository<Stock, Long> {
     Optional<Stock> findBySymbol(String symbol);
+
+    List<Stock> findByNameContaining(String keyword);
 }

--- a/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryService.java
+++ b/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryService.java
@@ -1,0 +1,7 @@
+package com.synergyx.trading.service.predictionService;
+
+import com.synergyx.trading.dto.stockDetail.StockDetailResponseDTO;
+
+public interface PredictionQueryService {
+    StockDetailResponseDTO.PredictionDTO getPredictionByStockId(Long stockId);
+}

--- a/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package com.synergyx.trading.service.predictionService;
+
+import com.synergyx.trading.dto.stockDetail.StockDetailResponseDTO;
+import org.springframework.stereotype.Service;
+
+import static com.synergyx.trading.util.ParsingUtil.toFormattedNumber;
+
+@Service
+public class PredictionQueryServiceImpl implements PredictionQueryService {
+    @Override
+    public StockDetailResponseDTO.PredictionDTO getPredictionByStockId(Long stockId) {
+        // TODO: 추후 predict 테이블에서 조회로 변경
+        return StockDetailResponseDTO.PredictionDTO.builder()
+                .upperBound(toFormattedNumber(63000.0))
+                .lowerBound(toFormattedNumber(53100.0))
+                .buyPrice(toFormattedNumber(52900.0))
+                .sellPrice(toFormattedNumber(62500.0))
+                .targetRange("20일 이내")
+                .build();
+    }
+}

--- a/src/main/java/com/synergyx/trading/service/stockDetailService/StockDetailQueryService.java
+++ b/src/main/java/com/synergyx/trading/service/stockDetailService/StockDetailQueryService.java
@@ -1,0 +1,7 @@
+package com.synergyx.trading.service.stockDetailService;
+
+import com.synergyx.trading.dto.stockDetail.StockDetailResponseDTO;
+
+public interface StockDetailQueryService {
+    StockDetailResponseDTO getStockDetail(Long stockId, Long userId);
+}

--- a/src/main/java/com/synergyx/trading/service/stockDetailService/StockDetailQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockDetailService/StockDetailQueryServiceImpl.java
@@ -1,0 +1,86 @@
+package com.synergyx.trading.service.stockDetailService;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.synergyx.trading.dto.stockDetail.StockDetailResponseDTO;
+import com.synergyx.trading.model.Stock;
+import com.synergyx.trading.model.StockDetail;
+import com.synergyx.trading.repository.InterestStockRepository;
+import com.synergyx.trading.repository.StockDetailRepository;
+import com.synergyx.trading.repository.StockRepository;
+import com.synergyx.trading.service.predictionService.PredictionQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.synergyx.trading.util.ParsingUtil.*;
+
+@Service
+@RequiredArgsConstructor
+public class StockDetailQueryServiceImpl implements StockDetailQueryService {
+
+    private final StockRepository stockRepository;
+    private final StockDetailRepository stockDetailRepository;
+    private final InterestStockRepository interestStockRepository;
+    private final PredictionQueryService predictionQueryService;
+
+    /**
+     * 종목 상세 정보를 조회합니다.
+     *
+     * @param stockId
+     * @param userId
+     * @return StockDetailResponseDTO
+     */
+    @Override
+    public StockDetailResponseDTO getStockDetail(Long stockId, Long userId) {
+        Stock stock = stockRepository.findById(stockId)
+                .orElseThrow(() -> new IllegalArgumentException("종목을 찾을 수 없습니다."));
+
+        StockDetail stockDetail = stockDetailRepository.findByStock_Id(stockId)
+                .orElseThrow(() -> new IllegalArgumentException("종목 상세 데이터를 찾을 수 없습니다."));
+
+        boolean isWatchlist = interestStockRepository.existsByUserIdAndStockId(userId, stockId);
+
+        // todo: 아직 미구현 → false 고정
+        boolean isTradeNotificationEnabled = false;
+
+        StockDetailResponseDTO.PredictionDTO prediction = predictionQueryService.getPredictionByStockId(stock.getId());
+
+        StockDetailResponseDTO.FinancialsDTO financials = parseFinancialData(stockDetail.getFinancialData());
+
+        return StockDetailResponseDTO.builder()
+                .stockName(stock.getName())
+                .price(toFormattedNumber(stockDetail.getPrice()))
+                .changeRate(stockDetail.getChangeRate() + "%")
+                //Todo: change amount 추가
+//                .changeAmount(toFormattedNumber(stockDetail.getChangeAmount()))
+                .changeAmount("600")
+                .isWatchlist(isWatchlist)
+                .isTradeNotificationEnabled(isTradeNotificationEnabled)
+                .prediction(prediction)
+                .financials(financials)
+                .build();
+    }
+
+    /**
+     * 재무 데이터를 문자열 형식에 맞게 파싱합니다.
+     *
+     * @param json 재무 데이터
+     * @return FinancialsDTO
+     */
+    private StockDetailResponseDTO.FinancialsDTO parseFinancialData(String json) {
+        try {
+            JsonNode node = new ObjectMapper().readTree(json);
+            return StockDetailResponseDTO.FinancialsDTO.builder()
+                    .pbr(toFormattedRatio(node.get("pbr").asText()))
+                    .per(toFormattedRatio(node.get("per").asText()))
+                    .psr(toFormattedRatio(node.get("psr").asText()))
+                    .roe(toFormattedPercentage(node.get("roe").asText(), 1))
+                    .marketCap(toFormattedMarketCap(node.get("market_cap").asText()))
+                    .dividendYield(toFormattedPercentage(node.get("dividend_yield").asText(), 2))
+                    .build();
+        } catch (Exception e) {
+            throw new RuntimeException("재무데이터 파싱 실패", e);
+        }
+    }
+}
+

--- a/src/main/java/com/synergyx/trading/service/stockSearchService/StockSearchQueryService.java
+++ b/src/main/java/com/synergyx/trading/service/stockSearchService/StockSearchQueryService.java
@@ -1,0 +1,9 @@
+package com.synergyx.trading.service.stockSearchService;
+
+import com.synergyx.trading.dto.stockSearch.StockSearchResponseDTO;
+
+import java.util.List;
+
+public interface StockSearchQueryService {
+    List<StockSearchResponseDTO> searchStocksByName(String keyword);
+}

--- a/src/main/java/com/synergyx/trading/service/stockSearchService/StockSearchQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockSearchService/StockSearchQueryServiceImpl.java
@@ -1,0 +1,32 @@
+package com.synergyx.trading.service.stockSearchService;
+
+import com.synergyx.trading.dto.stockSearch.StockSearchResponseDTO;
+import com.synergyx.trading.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockSearchQueryServiceImpl implements StockSearchQueryService {
+
+    private final StockRepository stockRepository;
+
+    /**
+     * 종목명을 기준으로 종목 리스트를 검색합니다.
+     *
+     * @param keyword 검색어
+     * @return StockSearchResponseDTO list
+     */
+    @Override
+    public List<StockSearchResponseDTO> searchStocksByName(String keyword) {
+        return stockRepository.findByNameContaining(keyword).stream()
+                .map(stock -> StockSearchResponseDTO.builder()
+                        .id(stock.getId())
+                        .name(stock.getName())
+                        .imageUrl(stock.getImageUrl())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/synergyx/trading/util/ParsingUtil.java
+++ b/src/main/java/com/synergyx/trading/util/ParsingUtil.java
@@ -32,4 +32,67 @@ public class ParsingUtil {
             return null;
         }
     }
+
+    /**
+     * 천 단위를 (,)로 구분하여 변환합니다.
+     *
+     * @param value double, long, int
+     * @return 문자열
+     */
+    public static String toFormattedNumber(double value) {
+        return String.format("%,.0f", value);
+    }
+
+    public static String toFormattedNumber(long value) {
+        return String.format("%,d", value);
+    }
+
+    public static String toFormattedNumber(int value) {
+        return String.format("%,d", value);
+    }
+
+    /**
+     * 문자열을 소수점 1자리 문자열로 변환합니다. (배)
+     *
+     * @param raw 문자열
+     * @return 변환된 문자열 또는 null
+     */
+    public static String toFormattedRatio(String raw) {
+        try {
+            return String.format("%.1f배", Double.parseDouble(raw));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * 문자열을 소수점 1,2자리 문자열로 변환합니다. (%)
+     *
+     * @param raw 문자열
+     * @return 변환된 문자열 또는 null
+     */
+    public static String toFormattedPercentage(String raw, int digits) {
+        try {
+            double value = Double.parseDouble(raw);
+            return String.format("%." + digits + "f%%", value);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * 억 단위 시가총액을 조 원 단위로 변환합니다.
+     *
+     * @param value 문자열
+     * @return 변환된 문자열 또는 null
+     */
+    public static String toFormattedMarketCap(String value) {
+        try {
+            long raw = Long.parseLong(value); // 억 원 단위
+            double trillion = raw / 10000.0;  // 조 원 단위로 변환
+            return String.format("%.1f조원", trillion);
+        } catch (Exception e) {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
종목 검색, 종목 상세 조회 api를 구현했습니다.

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- #26

## ⏳ 작업 내용
- 종목 검색 api 구현
- 종목 상세 조회 api 구현
- util 추가

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 상세 예외 처리 등은 나중에 추가
- 임시 값들이 많아서 추후 수정해야 함
  - prediction 부분 전체
  - stock detail : change amount 부분 데이터 없음