### PR TITLE
[FIX] 배당수익률 파싱 오류 수정 #26

### DIFF
--- a/src/main/java/com/synergyx/trading/service/stockDetailService/StockDetailQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockDetailService/StockDetailQueryServiceImpl.java
@@ -76,7 +76,9 @@ public class StockDetailQueryServiceImpl implements StockDetailQueryService {
                     .psr(toFormattedRatio(node.get("psr").asText()))
                     .roe(toFormattedPercentage(node.get("roe").asText(), 1))
                     .marketCap(toFormattedMarketCap(node.get("market_cap").asText()))
-                    .dividendYield(toFormattedPercentage(node.get("dividend_yield").asText(), 2))
+                    // todo : 배당수익률 데이터 불러온 후 수정해야 함.
+//                    .dividendYield(toFormattedPercentage(node.get("dividend_yield").asText(), 2))
+                    .dividendYield(toFormattedPercentage(null, 2))
                     .build();
         } catch (Exception e) {
             throw new RuntimeException("재무데이터 파싱 실패", e);


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
배당수익률 필드가 없어서 재무데이터 파싱 실패 오류 발생

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- #26

## ⏳ 작업 내용
- 

## 📸 스크린샷
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 