### PR TITLE
[FEAT] FastAPI - 백테스트 API 연동 #5

### DIFF
--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
@@ -35,7 +35,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 백테스팅 관련 예외 처리
     BACKTEST_NOT_FOUND(HttpStatus.NOT_FOUND, "BACKTEST404", "해당 백테스트 결과가 존재하지 않습니다."),
     BACKTEST_PERIOD_EXCEEDS_LIMIT(HttpStatus.BAD_REQUEST, "BACKTEST400", "백테스트 기간은 최대 5년까지 가능합니다."),
-
+    FASTAPI_BACKTEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BACKTEST502", "FastAPI 백테스트 서버 호출에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/synergyx/trading/config/WebClientConfig.java
+++ b/src/main/java/com/synergyx/trading/config/WebClientConfig.java
@@ -16,4 +16,11 @@ public class WebClientConfig {
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }
+    @Bean
+    public WebClient fastApiWebClient() {
+        return WebClient.builder()
+                .baseUrl("http://localhost:8000") // TODO: FastAPI 주소
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
 }

--- a/src/main/java/com/synergyx/trading/dto/backtest/BacktestRequestDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/backtest/BacktestRequestDTO.java
@@ -16,5 +16,8 @@ public class BacktestRequestDTO {
     // JSON 문자열 -> LocalDate 타입 형변환
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startDate; // 백테스트 시작일
+
+    // JSON 문자열 -> LocalDate 타입 형변환
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate endDate; // 백테스트 종료일
 }

--- a/src/main/java/com/synergyx/trading/dto/backtest/BacktestResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/backtest/BacktestResponseDTO.java
@@ -1,4 +1,5 @@
 package com.synergyx.trading.dto.backtest;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,7 +8,24 @@ import java.time.LocalDate;
 import java.util.List;
 
 public class BacktestResponseDTO  {
-    // 백테스트 실행
+
+    // FastAPI에서 받은 응답을 감싸는 Wrapper DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BacktestWrapperResponseDTO {
+
+        // camelCase로 매핑
+        @JsonProperty("is_success")
+        private boolean isSuccess;
+
+        private String code;
+        private String message;
+        private BacktestExecutionDTO data;
+    }
+
+    // 백테스트 실행 결과
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
+import com.synergyx.trading.service.backtestService.client.BacktestClientService;
 
 import java.time.LocalDate;
 
@@ -28,6 +29,7 @@ public class BacktestServiceImpl implements BacktestService {
     private final BacktestRepository backtestRepository;
     private final StockRepository stockRepository;
     private final UserRepository userRepository;
+    private final BacktestClientService backtestClientService;
 
     // 백테스팅 실행
     @Override
@@ -54,61 +56,46 @@ public class BacktestServiceImpl implements BacktestService {
 
         }
 
-        // fastAPI 연결 후 수정.
-        // 분석 결과를 DB에 저장
-        // 백테스트 분석 결과 (목데이터)
-        LocalDate executedAt = LocalDate.now();
-        double winRate = 65.2;
-        double averageReturn = 12.5;
-        int matchedCount = 8;
-        LocalDate maxReturnDate = LocalDate.of(2024, 3, 15);
-        double maxReturn = 25.4;
-        LocalDate minReturnDate = LocalDate.of(2024, 2, 10);
-        double minReturn = -7.8;
-        LocalDate lastMatchedDate = LocalDate.of(2024, 4, 20);
-        double lastMatchedReturn = 9.3;
-        double totalReturn = 88.3;
+        BacktestResponseDTO.BacktestExecutionDTO result = backtestClientService.callBacktestAPI(patternId, stockId, startDate, endDate);
 
-        // DB 저장용 엔티티 생성
-        Backtest backtest = Backtest.builder()
+        Backtest saved = backtestRepository.save(Backtest.builder()
                 .user(user)
                 .pattern(pattern)
                 .stock(stock)
-                .executedAt(executedAt)
+                .executedAt(LocalDate.now())
                 .startDate(startDate)
                 .endDate(endDate)
-                .winRate(winRate)
-                .averageReturn(averageReturn)
-                .matchedCount(matchedCount)
-                .maxReturnDate(maxReturnDate)
-                .maxReturn(maxReturn)
-                .minReturnDate(minReturnDate)
-                .minReturn(minReturn)
-                .lastMatchedDate(lastMatchedDate)
-                .lastMatchedReturn(lastMatchedReturn)
-                .totalReturn(totalReturn)
-                .build();
-
-        Backtest saved = backtestRepository.save(backtest);
+                .winRate(result.getWinRate())
+                .averageReturn(result.getAverageReturn())
+                .matchedCount(result.getMatchedCount())
+                .maxReturnDate(result.getMaxReturnDate())
+                .maxReturn(result.getMaxReturn())
+                .minReturnDate(result.getMinReturnDate())
+                .minReturn(result.getMinReturn())
+                .lastMatchedDate(result.getLastMatchedDate())
+                .lastMatchedReturn(result.getLastMatchedReturn())
+                .totalReturn(result.getTotalReturn())
+                .build());
 
         return BacktestResponseDTO.BacktestExecutionDTO.builder()
                 .backtestId(saved.getId())
-                .stockName(stock.getName())
-                .executedAt(executedAt)
-                .startDate(startDate)
-                .endDate(endDate)
-                .winRate(winRate)
-                .averageReturn(averageReturn)
-                .matchedCount(matchedCount)
-                .maxReturnDate(maxReturnDate)
-                .maxReturn(maxReturn)
-                .minReturnDate(minReturnDate)
-                .minReturn(minReturn)
-                .lastMatchedDate(lastMatchedDate)
-                .lastMatchedReturn(lastMatchedReturn)
-                .totalReturn(totalReturn)
+                .stockName(saved.getStock().getName())
+                .executedAt(saved.getExecutedAt())
+                .matchedCount(saved.getMatchedCount())
+                .startDate(saved.getStartDate())
+                .endDate(saved.getEndDate())
+                .winRate(saved.getWinRate())
+                .averageReturn(saved.getAverageReturn())
+                .maxReturn(saved.getMaxReturn())
+                .maxReturnDate(saved.getMaxReturnDate())
+                .minReturn(saved.getMinReturn())
+                .minReturnDate(saved.getMinReturnDate())
+                .totalReturn(saved.getTotalReturn())
+                .lastMatchedDate(saved.getLastMatchedDate())
+                .lastMatchedReturn(saved.getLastMatchedReturn())
                 .build();
     }
+
     // 과거 백테스팅 결과 상세 조회
     @Override
     @Transactional(readOnly = true)

--- a/src/main/java/com/synergyx/trading/service/backtestService/client/BacktestClientService.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/client/BacktestClientService.java
@@ -1,0 +1,48 @@
+package com.synergyx.trading.service.backtestService.client;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.dto.backtest.BacktestRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import com.synergyx.trading.dto.backtest.BacktestResponseDTO;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class BacktestClientService {
+
+    private final WebClient fastApiWebClient;
+
+    public BacktestResponseDTO.BacktestExecutionDTO callBacktestAPI(Long patternId, Long stockId, LocalDate startDate, LocalDate endDate) {
+        BacktestRequestDTO request = BacktestRequestDTO.builder()
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+
+        try {
+            BacktestResponseDTO.BacktestWrapperResponseDTO response = fastApiWebClient.post()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/api/v1/backtests")
+                            .queryParam("patternId", patternId)
+                            .queryParam("stockId", stockId)
+                            .build())
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(BacktestResponseDTO.BacktestWrapperResponseDTO.class)
+                    .block();
+
+            if (response == null || !response.isSuccess()) {
+                throw new GeneralException(ErrorStatus.FASTAPI_BACKTEST_FAILED);
+            }
+
+            return response.getData();
+
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.FASTAPI_BACKTEST_FAILED);
+        }
+    }
+}
+


### PR DESCRIPTION
## 🚀 개요
FastAPI - 백테스트 API 연동

## 📌 관련 이슈
- #5 

## ⏳ 작업 내용
- FastAPI API 호출하여 결과 수신
- FastAPI 응답 구조에 맞게 스프링부트 DTO 수정 및 호출 로직 보완
- 응답값을 DTO로 파싱 후 DB에 저장 및 응답 반환

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/f57e02c2-628e-460b-a8ad-927948498cd0)