### PR TITLE
Feat/#44 div change amount

### DIFF
--- a/src/main/java/com/synergyx/trading/config/KisProperties.java
+++ b/src/main/java/com/synergyx/trading/config/KisProperties.java
@@ -17,7 +17,7 @@ public class KisProperties {
     private String appSecret;
     @PostConstruct
     public void printKeys() {
-//        log.info("✅ KIS AppKey = {}", appKey);
-//        log.info("✅ KIS AppSecret = {}", appSecret); // todo: delete
+//        log.info("KIS AppKey = {}", appKey);
+//        log.info("KIS AppSecret = {}", appSecret);
     }
 }

--- a/src/main/java/com/synergyx/trading/controller/KisTestController.java
+++ b/src/main/java/com/synergyx/trading/controller/KisTestController.java
@@ -30,7 +30,7 @@ public class KisTestController {
         return ResponseEntity.ok("발급된 AccessToken: " + accessToken);
     }
 
-    @Operation(summary = "전체 Stock Detail 업데이트 API", description = "시가총액, 현재가, 등락률, per, pbr 을 가져옵니다.")
+    @Operation(summary = "전체 Stock Detail 업데이트 API", description = "시가총액, 현재가, 등락폭, 등락률, per, pbr 을 가져옵니다.")
     @PostMapping("/stocks/details")
     public ResponseEntity<?> updateStockDetails() {
         try {
@@ -43,7 +43,7 @@ public class KisTestController {
         }
     }
 
-    @Operation(summary = "개별 종목 Stock Detail 업데이트 API", description = "시가총액, 현재가, 등락률, per, pbr 을 가져옵니다.")
+    @Operation(summary = "개별 종목 Stock Detail 업데이트 API", description = "시가총액, 현재가, 등락폭, 등락률, per, pbr 을 가져옵니다.")
     @PostMapping("/stocks/{symbol}/details")
     public ResponseEntity<?> updateStockDetailsBySymbol(
             @Parameter(description = "종목 코드", required = true)
@@ -114,13 +114,12 @@ public class KisTestController {
         }
     }
 
-    // todo:수정
-    @Operation(summary = "전체 배당수익률 업데이트 API", description = "배당수익률 값을 가져옵니다.")
-//    @PostMapping("/stocks/div")
+    @Operation(summary = "전체 배당금 업데이트 API", description = "배당금 값을 가져옵니다.")
+    @PostMapping("/stocks/div")
     public ResponseEntity<?> updateDiv() {
         try {
-            kisDividendScheduleService.updateDividendYieldAll();
-            return ResponseEntity.ok(ApiResponse.onSuccess("STOCK_UPDATE_SUCCESS", "배당수익률 저장 완료"));
+            kisDividendScheduleService.updateDividendAll();
+            return ResponseEntity.ok(ApiResponse.onSuccess("STOCK_UPDATE_SUCCESS", "배당금 저장 완료"));
         } catch (Exception e) {
             return ResponseEntity
                     .status(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -128,15 +127,14 @@ public class KisTestController {
         }
     }
 
-    // todo:수정
-    @Operation(summary = "개별 종목 배당수익률 업데이트 API", description = "개별 종목의 배당수익률 값을 가져옵니다.")
-//    @PostMapping("/stocks/{symbol}/div")
+    @Operation(summary = "개별 종목 배당금 업데이트 API", description = "개별 종목의 배당금 값을 가져옵니다.")
+    @PostMapping("/stocks/{symbol}/div")
     public ResponseEntity<?> updateDivBySymbol(
             @Parameter(description = "종목 코드", required = true)
             @PathVariable String symbol) {
         try {
-            kisDividendScheduleService.updateDividendYieldBySymbol(symbol);
-            return ResponseEntity.ok(ApiResponse.onSuccess("STOCK_UPDATE_SUCCESS", "배당수익률 저장 완료"));
+            kisDividendScheduleService.updateDividendBySymbol(symbol);
+            return ResponseEntity.ok(ApiResponse.onSuccess("STOCK_UPDATE_SUCCESS", "배당금 저장 완료"));
         } catch (Exception e) {
             return ResponseEntity
                     .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/synergyx/trading/model/StockDetail.java
+++ b/src/main/java/com/synergyx/trading/model/StockDetail.java
@@ -25,6 +25,9 @@ public class StockDetail extends BaseEntity {
     @Column
     private Double price;
 
+    @Column(name = "change_amount")
+    private Double changeAmount;
+
     @Column(name = "change_rate")
     private Double changeRate;
 

--- a/src/main/java/com/synergyx/trading/service/kisService/KisDividendScheduleService.java
+++ b/src/main/java/com/synergyx/trading/service/kisService/KisDividendScheduleService.java
@@ -1,5 +1,6 @@
 package com.synergyx.trading.service.kisService;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -15,8 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static com.synergyx.trading.util.ParsingUtil.toDouble;
 
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 @Service
@@ -30,127 +36,269 @@ public class KisDividendScheduleService {
     private final ObjectMapper objectMapper;
 
     /**
-     * 전체 종목의 배당수익률 (dividend_yield)을 업데이트합니다.
+     * 전체 종목의 배당금 (dividend_amount)을 업데이트합니다.
      */
     @Transactional
-    public void updateDividendYieldAll() {
+    public void updateDividendAll() {
         List<Stock> stocks = stockRepository.findAll();
 
         for (Stock stock : stocks) {
             try {
-                updateDividendYieldInternal(stock);
-                Thread.sleep(200); // API 호출 제한
+                updateDividendAmountInternal(stock);
+                Thread.sleep(300); // API 호출 제한
             } catch (Exception e) {
-                log.error("[DIV] {} 배당수익률 업데이트 실패: {}", stock.getSymbol(), e.getMessage(), e);
+                log.error("[DIV] {} 배당금 업데이트 실패: {}", stock.getSymbol(), e.getMessage(), e);
             }
         }
     }
 
     /**
-     * 개별 종목의 배당수익률 (dividend_yield)을 업데이트합니다.
+     * 개별 종목의 배당금 (dividend_amount)을 업데이트합니다.
      */
     @Transactional
-    public void updateDividendYieldBySymbol(String symbol) {
+    public void updateDividendBySymbol(String symbol) {
         Stock stock = stockRepository.findBySymbol(symbol)
                 .orElseThrow(() -> new IllegalArgumentException("해당 종목 없음: " + symbol));
 
         try {
-            updateDividendYieldInternal(stock);
+            updateDividendAmountInternal(stock);
         } catch (Exception e) {
-            log.error("[DIV] {} 배당수익률 업데이트 실패: {}", symbol, e.getMessage(), e);
+            log.error("[DIV] {} 배당금 업데이트 실패: {}", symbol, e.getMessage(), e);
         }
     }
 
     /**
-     * 배당수익률을 저장합니다.
+     * 개별 종목의 배당금을 저장합니다.
      *
      * @param stock
      * @throws Exception
      */
-    private void updateDividendYieldInternal(Stock stock) throws Exception {
+    public void updateDividendAmountInternal(Stock stock) throws Exception {
+        JsonNode output = fetchAndParseDividendResponse(stock);
+        if (output == null) {
+            log.warn("[DIV] 응답에 배당 정보 없음 - symbol: {}", stock.getSymbol());
+            return;
+        }
+
+        Double totalDividend = calculateValidAnnualDividend(output, stock.getSymbol());
+        if (totalDividend == null || totalDividend <= 0) {
+            log.warn("[DIV] 유효 배당금 없음 - symbol: {}", stock.getSymbol());
+            return;
+        }
+
+        updateStockDetailWithDividend(stock, totalDividend);
+    }
+
+    /**
+     * 연간 배당일정 데이터를 파싱합니다.
+     *
+     * @param stock
+     * @return
+     * @throws IOException
+     */
+    private JsonNode fetchAndParseDividendResponse(Stock stock) throws IOException {
         ObjectNode response = fetchDividendSchedule(stock.getSymbol());
 
-//        log.info("[PSR] 응답 전체 JSON ({}):\n{}", stock.getSymbol(), objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(response));
+//        log.info("[DIV] 응답 전체 JSON ({}):\n{}", stock.getSymbol(),
+//                objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(response));
 
         JsonNode output = response.get("output1");
-        if (output == null || !output.isArray()) {
-            log.warn("[DIV] 응답에 output1 없음 - symbol: {}", stock.getSymbol());
-            return;
+        return (output != null && output.isArray()) ? output : null;
+    }
+
+    /**
+     * 연간 유효 배당금 합산 계산
+     * - 지급일 존재 + 배당금 > 0 + (종류: 없음 or "보통")인 항목만 유효로 간주
+     * - 기준일(record_date) 기준으로 연도 그룹핑
+     * - 기준 연도: 최근 1년(없으면 2년 fallback)
+     * - 결산배당이면서 다음해 4월 이내 지급 → 전년도(record_date) 기준 연도에 포함
+     *
+     * @param output KIS 배당 정보 응답 (output1)
+     * @param symbol 종목 코드
+     * @return 연간 배당금 (없으면 null)
+     */
+    private Double calculateValidAnnualDividend(JsonNode output, String symbol) {
+        // 연도별 배당금 합산
+        Map<String, Double> yearToSum = buildAnnualDividendMap(output, symbol);
+//        log.info("[DIV] yearToSum = {}", yearToSum);
+
+        String lastYear = String.valueOf(LocalDate.now().getYear() - 1);
+        String prevYear = String.valueOf(LocalDate.now().getYear() - 2);
+
+        // 2024년 배당금 우선 사용, 없으면 2023으로 fallback
+        Double totalDividend = yearToSum.getOrDefault(lastYear, 0.0);
+        if (totalDividend > 0) return totalDividend;
+
+        totalDividend = yearToSum.getOrDefault(prevYear, 0.0);
+        if (totalDividend > 0) {
+//            log.info("[DIV] {}년도 배당금 fallback 사용 - symbol: {}, totalDividend: {}", prevYear, symbol, totalDividend);
+            return totalDividend;
         }
 
-        // 결산 데이터 필터링
-        JsonNode match = StreamSupport.stream(output.spliterator(), false)
-                .filter(node -> stock.getSymbol().equals(node.path("sht_cd").asText()))
-                .filter(node -> "결산".equals(node.path("divi_kind").asText()))
-                .filter(node -> {
-                    String recordDate = node.path("record_date").asText();
-                    return recordDate != null && recordDate.length() >= 6 && recordDate.substring(4, 6).equals("12");
-                })
-                .findFirst()
+        return null;
+    }
+
+    /**
+     * 유효한 배당 정보를 기준일(record_date) 기준으로 연도별 그룹핑하여 합산
+     */
+    private Map<String, Double> buildAnnualDividendMap(JsonNode output, String symbol) {
+        return StreamSupport.stream(output.spliterator(), false)
+                .filter(node -> symbol.equals(node.path("sht_cd").asText("")))
+                .map(this::mapToDividendWithRecordYear)
+                .filter(Objects::nonNull)
+                .collect(Collectors.groupingBy(
+                        DividendEntry::year,
+                        Collectors.summingDouble(DividendEntry::amount)
+                ));
+    }
+
+    /**
+     * 배당 정보를 유효성 검증 후 기준연도 + 금액으로 매핑
+     * - 지급일 존재 + 오늘 기준 이미 지급된 건
+     * - 보통주
+     * - 기준연도: record_date의 연도
+     * - 결산 배당이면서 다음해 4월 이내 지급된 건도 그대로 record_date 기준 연도에 포함
+     */
+    private DividendEntry mapToDividendWithRecordYear(JsonNode node) {
+        String payDateStr = node.path("divi_pay_dt").asText("");
+        String amountStr = node.path("per_sto_divi_amt").asText("");
+        String kind = node.path("stk_kind").asText("");
+        String diviKind = node.path("divi_kind").asText("");
+
+        String recordDate = node.path("record_date").asText("");
+
+        if (recordDate.length() < 4 || payDateStr.isBlank() || amountStr.isBlank() || amountStr.equals("0"))
+            return null;
+        if (!kind.isBlank() && !kind.equals("보통")) return null;
+
+        try {
+            LocalDate payDate = LocalDate.parse(payDateStr, DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+            if (payDate.isAfter(LocalDate.now())) return null; // 아직 지급되지 않음
+
+            double amount = toDouble(amountStr);
+
+            String year;
+            if ("결산".equals(diviKind)) {
+                if (payDate.getMonthValue() <= 4) {
+                    year = String.valueOf(payDate.getYear() - 1); // 4월 이전인 경우 전년도로 처리
+                } else {
+                    year = String.valueOf(payDate.getYear()); // fallback
+                }
+            } else {
+                year = String.valueOf(payDate.getYear());
+            }
+
+//            log.info("[DIV] 유효 배당 - symbol: {}, year: {}, amount: {}", node.path("sht_cd").asText(), year, amount);
+
+            return new DividendEntry(year, amount);
+
+        } catch (Exception e) {
+            log.warn("[DIV] 배당 파싱 실패 - symbol: {}, record_date: {}, 지급일: {}", node.path("sht_cd").asText(""), recordDate, payDateStr);
+            return null;
+        }
+    }
+
+    /**
+     * 연도별 배당 합산을 위한 내부 구조
+     */
+    private record DividendEntry(String year, double amount) {
+    }
+
+    /**
+     * 배당금을 기존 값과 비교 후 db에 저장합니다.
+     *
+     * @param stock
+     * @param totalDividend
+     * @throws JsonProcessingException
+     */
+    private void updateStockDetailWithDividend(Stock stock, double totalDividend) throws JsonProcessingException {
+        StockDetail detail = stockDetailRepository.findById(stock.getId())
                 .orElse(null);
-
-        if (match == null) {
-            log.warn("[DIV] 조건에 맞는 결산 배당 데이터 없음 - symbol: {}", stock.getSymbol());
-            return;
-        }
-
-        Double dividendAmount = toDouble(match.path("per_sto_divi_amt").asText());
-        if (dividendAmount == null || dividendAmount <= 0) {
-            log.warn("[DIV] 유효하지 않은 현금배당금 - symbol: {}, value: {}", stock.getSymbol(), dividendAmount);
-            return;
-        }
-
-        StockDetail detail = stockDetailRepository.findById(stock.getId()).orElse(null);
         if (detail == null) {
             log.warn("[DIV] StockDetail 없음 - symbol: {}", stock.getSymbol());
             return;
         }
 
-        Double price = detail.getPrice();
-        if (price == null || price <= 0) {
-            log.warn("[DIV] 현재가 정보 없음 또는 0 이하 - symbol: {}, price: {}", stock.getSymbol(), price);
-            return;
-        }
-
-        // 배당수익률 계산
-        double dividendYield = (dividendAmount / price) * 100;
-        String newYieldStr = String.format("%.2f", dividendYield);
-
         ObjectNode financialDataNode = (detail.getFinancialData() != null)
                 ? (ObjectNode) objectMapper.readTree(detail.getFinancialData())
                 : objectMapper.createObjectNode();
 
-        String existingYield = financialDataNode.path("dividend_yield").asText().strip();
+        String existing = financialDataNode.path("dividend_amount").asText();
+        String newAmountStr = String.format("%.0f", totalDividend);
 
-        if (existingYield.equals(newYieldStr)) {
-            log.info("[DIV] 배당수익률 동일 ({}%), 업데이트 생략 - symbol: {}", newYieldStr, stock.getSymbol());
+        if (existing.equals(newAmountStr)) {
+            log.info("[DIV] 배당금 동일 ({}원), 업데이트 생략 - symbol: {}", newAmountStr, stock.getSymbol());
             return;
         }
 
-        financialDataNode.put("dividend_yield", newYieldStr);
+        financialDataNode.put("dividend_amount", newAmountStr);
         detail.setFinancialData(financialDataNode.toString());
         stockDetailRepository.save(detail);
 
-        log.info("[DIV] 배당수익률 업데이트 완료 - symbol: {}, {}%", stock.getSymbol(), newYieldStr);
+        log.info("[DIV] 배당금 업데이트 완료 - symbol: {}, {}원", stock.getSymbol(), newAmountStr);
     }
 
     /**
-     * 특정 종목의 배당일정 데이터를 요청합니다.
+     * 주가와 배당금 기준으로 배당수익률을 계산합니다.
+     * 배당금 또는 가격 정보가 없거나 잘못된 경우 0.0을 반환합니다.
+     *
+     * @param detail
+     * @return
+     */
+    public Double calculateDividendYield(StockDetail detail) {
+        if (detail == null || detail.getFinancialData() == null) {
+            log.warn("[DIV] StockDetail 또는 FinancialData가 null - id: {}",
+                    detail != null ? detail.getId() : "null");
+            return null;
+        }
+
+        Double price = detail.getPrice();
+        if (price == null || price <= 0) {
+            log.warn("[DIV] 주가 정보 누락 또는 유효하지 않음 - id: {}, price: {}",
+                    detail.getId(), price);
+            return null;
+        }
+
+        try {
+            JsonNode data = objectMapper.readTree(detail.getFinancialData());
+            Double dividend = toDouble(data.path("dividend_amount").asText());
+
+            if (dividend == null || dividend <= 0) {
+                log.info("[DIV] 유효한 배당금 없음 - id: {}, dividend: {}", detail.getId(), dividend);
+                return null;
+            }
+
+            double result = (dividend / price) * 100;
+            return Math.round(result * 100.0) / 100.0; // 소수점 둘째 자리 반올림
+
+        } catch (Exception e) {
+            log.error("[DIV] 배당수익률 계산 중 예외 발생 - id: {}", detail.getId(), e);
+            return null;
+        }
+    }
+
+    /**
+     * 특정 종목의 연간 배당일정 데이터를 요청합니다.
      * KIS dividend API (TR_ID: HHKDB669102C0) 호출.
      *
      * @param symbol
      * @return
      */
     private ObjectNode fetchDividendSchedule(String symbol) {
+        String lastlastYear = String.valueOf(LocalDate.now().getYear() - 2);
+        String currentYear = String.valueOf(LocalDate.now().getYear());
+        String from = lastlastYear + "0101";   // ex: 20230101
+        String to = currentYear + "1231";     // ex: 20251231
+
         return (ObjectNode) kisApiClient.get(
                 "/uapi/domestic-stock/v1/ksdinfo/dividend",
                 Map.of(
-                        "cts1", "",
+                        "cts", "",
                         "gb1", "0",
-                        "f_dt", "20240930",
-                        "t_dt", "20241231",
+                        "f_dt", from,
+                        "t_dt", to,
                         "sht_cd", symbol,
-                        "high_gb", "0"
+                        "high_gb", ""
                 ),
                 "HHKDB669102C0"
         );

--- a/src/main/java/com/synergyx/trading/service/kisService/KisOhlcvUpdateService.java
+++ b/src/main/java/com/synergyx/trading/service/kisService/KisOhlcvUpdateService.java
@@ -163,7 +163,7 @@ public class KisOhlcvUpdateService {
     }
 
     /**
-     * 1분봉 캔들 데이터를 파싱하고 DB에 저장합니다.
+     * 1분봉 캔들 데이터를 파싱하고 DB에 저장합니다. 사용 x
      *
      * @param candles 캔들 배열
      * @param stock   종목

--- a/src/main/java/com/synergyx/trading/service/kisService/KisPriceUpdateService.java
+++ b/src/main/java/com/synergyx/trading/service/kisService/KisPriceUpdateService.java
@@ -30,7 +30,7 @@ public class KisPriceUpdateService {
     private final ObjectMapper objectMapper;
 
     /**
-     * 시가총액/현재가/등락률 + PER/PBR 을 업데이트합니다.
+     * 시가총액/현재가/등락폭/등락률 + PER/PBR 을 업데이트합니다.
      */
     @Transactional
     public void updateStockDetailsFromKis() {
@@ -92,6 +92,7 @@ public class KisPriceUpdateService {
                 ),
                 "FHKST01010100"
         );
+//        log.info("[Price] 응답 전체 JSON ({}):\n{}", response);
 
         return (ObjectNode) response.get("output");
     }
@@ -106,8 +107,19 @@ public class KisPriceUpdateService {
      * @throws JsonProcessingException
      */
     private StockDetail createOrUpdateStockDetail(Stock stock, ObjectNode jsonNode) throws JsonProcessingException {
-        Double price = toDouble(jsonNode.get("stck_prpr").asText());
-        Double changeRate = toDouble(jsonNode.get("prdy_ctrt").asText());
+        Double price = toDouble(jsonNode.get("stck_prpr").asText()); // 현재가
+
+        String signCode = jsonNode.get("prdy_vrss_sign").asText(); // 등락부호 (1 : 상한, 2 : 상승, 3 : 보합, 4 : 하한, 5 : 하락)
+        Double rawChangeAmount = toDouble(jsonNode.get("prdy_vrss").asText()); // 등락폭
+
+        Double signedChangeAmount = switch (signCode) {
+            case "1", "2" -> rawChangeAmount;   // 상한 or 상승 → +
+            case "4", "5" -> -rawChangeAmount;  // 하한 or 하락 → -
+            case "3" -> 0.0;                    // 보합 → 0
+            default -> 0.0;
+        };
+
+        Double changeRate = toDouble(jsonNode.get("prdy_ctrt").asText()); // 등락률
 
         StockDetail stockDetail = stockDetailRepository.findById(stock.getId())
                 .orElse(StockDetail.builder().stock(stock).build());
@@ -129,6 +141,7 @@ public class KisPriceUpdateService {
         }
 
         stockDetail.setPrice(price);
+        stockDetail.setChangeAmount(signedChangeAmount);
         stockDetail.setChangeRate(changeRate);
         stockDetail.setFinancialData(financialDataNode.toString());
 

--- a/src/main/java/com/synergyx/trading/service/stockService/detail/StockDetailQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/detail/StockDetailQueryServiceImpl.java
@@ -9,14 +9,17 @@ import com.synergyx.trading.repository.InterestStockRepository;
 import com.synergyx.trading.repository.StockDetailRepository;
 import com.synergyx.trading.repository.StockRepository;
 import com.synergyx.trading.service.InterestStockService.InterestStockCommandService;
+import com.synergyx.trading.service.kisService.KisDividendScheduleService;
 import com.synergyx.trading.service.predictionService.PredictionQueryService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.synergyx.trading.util.ParsingUtil.*;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class StockDetailQueryServiceImpl implements StockDetailQueryService {
 
@@ -25,6 +28,7 @@ public class StockDetailQueryServiceImpl implements StockDetailQueryService {
     private final InterestStockRepository interestStockRepository;
     private final PredictionQueryService predictionQueryService;
     private final InterestStockCommandService interestStockCommandService;
+    private final KisDividendScheduleService kisDividendScheduleService;
 
     /**
      * 종목 상세 정보를 조회합니다.
@@ -52,7 +56,7 @@ public class StockDetailQueryServiceImpl implements StockDetailQueryService {
 
         StockDetailResponseDTO.PredictionDTO prediction = predictionQueryService.getPredictionByStockId(stock.getId());
 
-        StockDetailResponseDTO.FinancialsDTO financials = parseFinancialData(stockDetail.getFinancialData());
+        StockDetailResponseDTO.FinancialsDTO financials = parseFinancialData(stockDetail);
 
         return StockDetailResponseDTO.builder()
                 .stockName(stock.getName())
@@ -69,23 +73,30 @@ public class StockDetailQueryServiceImpl implements StockDetailQueryService {
     /**
      * 재무 데이터를 문자열 형식에 맞게 파싱합니다.
      *
-     * @param json 재무 데이터
+     * @param stockDetail 종목 상세
      * @return FinancialsDTO
      */
-    private StockDetailResponseDTO.FinancialsDTO parseFinancialData(String json) {
+    private StockDetailResponseDTO.FinancialsDTO parseFinancialData(StockDetail stockDetail) {
         try {
-            JsonNode node = new ObjectMapper().readTree(json);
+            JsonNode node = new ObjectMapper().readTree(stockDetail.getFinancialData());
+
+            // 배당수익률 계산
+            // 배당금 정보가 없거나 계산 불가할 경우 "-"로 대체
+            Double dividendYield = kisDividendScheduleService.calculateDividendYield(stockDetail);
+            String formattedDividendYield = (dividendYield == null)
+                    ? "-"
+                    : toFormattedPercentage(dividendYield, 2);
+
             return StockDetailResponseDTO.FinancialsDTO.builder()
                     .pbr(toFormattedRatio(node.get("pbr").asText()))
                     .per(toFormattedRatio(node.get("per").asText()))
                     .psr(toFormattedRatio(node.get("psr").asText()))
                     .roe(toFormattedPercentage(node.get("roe").asText(), 1))
                     .marketCap(toFormattedMarketCap(node.get("market_cap").asText()))
-                    // todo : 배당수익률 데이터 불러온 후 수정해야 함.
-//                    .dividendYield(toFormattedPercentage(node.get("dividend_yield").asText(), 2))
-                    .dividendYield("2.41%")
+                    .dividendYield(formattedDividendYield)
                     .build();
         } catch (Exception e) {
+            log.error("[DETAIL] 재무데이터 파싱 실패 - symbol Id: {}", stockDetail.getId(), e);
             throw new RuntimeException("재무데이터 파싱 실패", e);
         }
     }

--- a/src/main/java/com/synergyx/trading/service/stockService/detail/StockDetailQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/detail/StockDetailQueryServiceImpl.java
@@ -58,9 +58,7 @@ public class StockDetailQueryServiceImpl implements StockDetailQueryService {
                 .stockName(stock.getName())
                 .price(toFormattedNumber(stockDetail.getPrice()))
                 .changeRate(stockDetail.getChangeRate() + "%")
-                //Todo: change amount 추가
-//                .changeAmount(toFormattedNumber(stockDetail.getChangeAmount()))
-                .changeAmount("600")
+                .changeAmount(toFormattedNumber(stockDetail.getChangeAmount()))
                 .isWatchlist(isWatchlist)
                 .isTradeNotificationEnabled(isTradeNotificationEnabled)
                 .prediction(prediction)

--- a/src/main/java/com/synergyx/trading/util/ParsingUtil.java
+++ b/src/main/java/com/synergyx/trading/util/ParsingUtil.java
@@ -54,6 +54,11 @@ public class ParsingUtil {
         return String.format("%,d", value);
     }
 
+    public static String toFormattedNumber(Double value) {
+        if (value == null) return "-";
+        return String.format("%,.0f", value);
+    }
+
     /**
      * 문자열을 소수점 1자리 문자열로 변환합니다. (배)
      *
@@ -87,7 +92,7 @@ public class ParsingUtil {
      * Double 값을 퍼센트 포맷 문자열로 반환합니다.
      *
      * @param value
-     * @param digits
+     * @param digits 소수점 자리 지정 ex: 1
      * @return 변환된 문자열
      */
     public static String toFormattedPercentage(Double value, int digits) {


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
배당수익률, 등락폭 데이터를 연동했습니다.

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #44

## ⏳ 작업 내용
- 배당수익률 계산
  - 연간 배당금은 자주 바뀌지 않기 때문에 kis에서 배당금만 받아와 저장,
  - 종목 상세에서 배당수익률 요청 시 현재가로 계산하여 응답하는 방식으로 변경함.
- 최신 연간 배당금 데이터 연동
- 등락폭 데이터 연동


## 📸 스크린샷
- 
<img width="850" alt="스크린샷 2025-07-03 오전 1 56 56" src="https://github.com/user-attachments/assets/d978386f-2028-43ad-9cfc-74f29183498e" />

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 배당금이 없는 종목들은 "-" 를 반환합니다.
- 재무 데이터가 생각보다 자주 바뀌어서
 json -> 테이블 분리 등으로 컬럼으로 바꾸는게 더 효율적인 것 같다는 생각이 들었습니다.. 