### PR TITLE
[MOVE] 패턴 기간 enum 경로 이동 및 연관 수정 #3

### DIFF
--- a/src/main/java/com/synergyx/trading/enums/PeriodUnit.java
+++ b/src/main/java/com/synergyx/trading/enums/PeriodUnit.java
@@ -1,4 +1,4 @@
-package com.synergyx.trading.model;
+package com.synergyx.trading.enums;
 
 public enum PeriodUnit {
     SEC, MINUTE, HOUR, DAY, MONTH;

--- a/src/main/java/com/synergyx/trading/model/Pattern.java
+++ b/src/main/java/com/synergyx/trading/model/Pattern.java
@@ -1,6 +1,7 @@
 package com.synergyx.trading.model;
 
 import com.synergyx.trading.converter.PatternPointsConverter;
+import com.synergyx.trading.enums.PeriodUnit;
 import com.synergyx.trading.model.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/synergyx/trading/service/patternService/PatternCommandServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternService/PatternCommandServiceImpl.java
@@ -4,7 +4,7 @@ import com.synergyx.trading.apiPayload.exception.GeneralException;
 import com.synergyx.trading.dto.pattern.PatternRequestDTO;
 import com.synergyx.trading.dto.pattern.PatternResponseDTO;
 import com.synergyx.trading.model.Pattern;
-import com.synergyx.trading.model.PeriodUnit;
+import com.synergyx.trading.enums.PeriodUnit;
 import com.synergyx.trading.model.User;
 import com.synergyx.trading.repository.BacktestRepository;
 import com.synergyx.trading.repository.PatternApplyRepository;


### PR DESCRIPTION
## 🚀 개요
기존 PeriodUnit 경로 이동

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- #3 

## ⏳ 작업 내용
- 기존 PeriodUnit 경로를 '/model/PeriodUnit.java' 에서 '/enums/PeriodUnit.java' 로 이동시켰습니다.