### PR TITLE
[FEAT] 패턴 적용 시 진입 시점 및 진입 가격 저장 기능 추가 #57

### DIFF
--- a/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyRequestDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyRequestDTO.java
@@ -16,7 +16,7 @@ public class PatternApplyRequestDTO {
     public static class PatternApplyDTO {
         private Long patternId; // 패턴 아이디
         private Long stockId; // 종목 아이디
-        private LocalDateTime detectFrom; // 감지 시작일
+        private LocalDateTime entryDate; // 진입 시점 (감지 시작일)
     }
 }
 

--- a/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyResponseDTO.java
@@ -27,7 +27,8 @@ public class PatternApplyResponseDTO {
     public static class PatternApplyResultDTO {
         private Long patternApplyId;
         private Boolean isAlertEnabled;
-        private LocalDateTime detectFrom;
+        private LocalDateTime entryDate;
+        private Double entryPrice;
     }
     // 알림 토글
     @Getter

--- a/src/main/java/com/synergyx/trading/model/PatternApply.java
+++ b/src/main/java/com/synergyx/trading/model/PatternApply.java
@@ -40,8 +40,12 @@ public class PatternApply extends BaseEntity {
     @Column(name = "is_alert_enabled", nullable = false)
     private Boolean isAlertEnabled;
 
-    // 감지 시작일
-    @Column(name = "detect_from", nullable = false)
-    private LocalDateTime detectFrom;
+    // 진입 시점 (감지 시작일)
+    @Column(name = "entry_date", nullable = false)
+    private LocalDateTime entryDate;
+
+    // 진입 당시 가격
+    @Column(name = "entry_price", nullable = false)
+    private Double entryPrice;
 }
 

--- a/src/main/java/com/synergyx/trading/repository/StockOhlcvRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/StockOhlcvRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface StockOhlcvRepository extends JpaRepository<StockOhlcv, Long> {
@@ -40,11 +41,6 @@ public interface StockOhlcvRepository extends JpaRepository<StockOhlcv, Long> {
     List<StockOhlcv> findByStockIdAndTimestampBetweenOrderByTimestampAsc(Long stockId, LocalDateTime start, LocalDateTime end);
 
     // entryDate (포함) 이전의 가장 최근의 종가 조회
-    @Query("""
-                SELECT o FROM StockOhlcv o
-                WHERE o.stock.id = :stockId
-                AND o.timestamp <= :entryDate
-                ORDER BY o.timestamp DESC
-            """)
-    List<StockOhlcv> findTopByStockIdAndTimestampBefore(@Param("stockId") Long stockId, @Param("entryDate") LocalDateTime entryDate, Pageable pageable);
+    Optional<StockOhlcv> findTop1ByStockIdAndTimestampLessThanEqualOrderByTimestampDesc(Long stockId, LocalDateTime entryDate);
+
 }

--- a/src/main/java/com/synergyx/trading/repository/StockOhlcvRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/StockOhlcvRepository.java
@@ -38,4 +38,13 @@ public interface StockOhlcvRepository extends JpaRepository<StockOhlcv, Long> {
 
     // 기간별 조회 (정렬 포함)
     List<StockOhlcv> findByStockIdAndTimestampBetweenOrderByTimestampAsc(Long stockId, LocalDateTime start, LocalDateTime end);
+
+    // entryDate (포함) 이전의 가장 최근의 종가 조회
+    @Query("""
+                SELECT o FROM StockOhlcv o
+                WHERE o.stock.id = :stockId
+                AND o.timestamp <= :entryDate
+                ORDER BY o.timestamp DESC
+            """)
+    List<StockOhlcv> findTopByStockIdAndTimestampBefore(@Param("stockId") Long stockId, @Param("entryDate") LocalDateTime entryDate, Pageable pageable);
 }

--- a/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyServiceImpl.java
@@ -4,15 +4,10 @@ import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
 import com.synergyx.trading.apiPayload.exception.GeneralException;
 import com.synergyx.trading.dto.patternApply.PatternApplyRequestDTO;
 import com.synergyx.trading.dto.patternApply.PatternApplyResponseDTO;
-import com.synergyx.trading.model.Pattern;
-import com.synergyx.trading.model.PatternApply;
-import com.synergyx.trading.model.Stock;
-import com.synergyx.trading.model.User;
-import com.synergyx.trading.repository.PatternApplyRepository;
-import com.synergyx.trading.repository.PatternRepository;
-import com.synergyx.trading.repository.StockRepository;
-import com.synergyx.trading.repository.UserRepository;
+import com.synergyx.trading.model.*;
+import com.synergyx.trading.repository.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +21,7 @@ public class PatternApplyServiceImpl implements PatternApplyService {
     private final PatternApplyRepository patternApplyRepository;
     private final UserRepository userRepository;
     private final StockRepository stockRepository;
+    private final StockOhlcvRepository stockOhlcvRepository;
 
     // 패턴 적용
     @Override
@@ -44,16 +40,26 @@ public class PatternApplyServiceImpl implements PatternApplyService {
         Stock stock = stockRepository.findById(request.getStockId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.STOCK_NOT_FOUND));
 
-        LocalDateTime detectFrom = request.getDetectFrom() != null
-               ? request.getDetectFrom()
+        LocalDateTime entryDate = request.getEntryDate() != null
+               ? request.getEntryDate()
                 : LocalDateTime.now();  // 감지 시작일이 null이면 현재 시간으로 대체
+
+        // 매수 가격 조회
+        StockOhlcv latestOhlcv = stockOhlcvRepository
+                .findTopByStockIdAndTimestampBefore(request.getStockId(), entryDate, PageRequest.of(0, 1))
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CANDLE_DATA_NOT_FOUND));
+
+        Double entryPrice = latestOhlcv.getClose();
 
         PatternApply apply = PatternApply.builder()
                 .pattern(pattern)
                 .stock(stock)
                 .user(user)
                 .isAlertEnabled(false)
-                .detectFrom(detectFrom)
+                .entryDate(entryDate)
+                .entryPrice(entryPrice)
                 .build();
 
         PatternApply saved = patternApplyRepository.save(apply);
@@ -61,7 +67,8 @@ public class PatternApplyServiceImpl implements PatternApplyService {
         return PatternApplyResponseDTO.PatternApplyResultDTO.builder()
                 .patternApplyId(saved.getId())
                 .isAlertEnabled(saved.getIsAlertEnabled())
-                .detectFrom(saved.getDetectFrom())
+                .entryDate(saved.getEntryDate())
+                .entryPrice(saved.getEntryPrice())
                 .build();
     }
 
@@ -71,8 +78,8 @@ public class PatternApplyServiceImpl implements PatternApplyService {
     public PatternApplyResponseDTO.PatternApplyToggleDTO toggleNotification(Long userId, Long patternApplyId) {
 
         // 사용자 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+//        User user = userRepository.findById(userId)
+//                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 패턴 적용 정보 조회
         PatternApply patternApply = patternApplyRepository.findById(patternApplyId)

--- a/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyServiceImpl.java
@@ -7,7 +7,6 @@ import com.synergyx.trading.dto.patternApply.PatternApplyResponseDTO;
 import com.synergyx.trading.model.*;
 import com.synergyx.trading.repository.*;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,9 +45,7 @@ public class PatternApplyServiceImpl implements PatternApplyService {
 
         // 매수 가격 조회
         StockOhlcv latestOhlcv = stockOhlcvRepository
-                .findTopByStockIdAndTimestampBefore(request.getStockId(), entryDate, PageRequest.of(0, 1))
-                .stream()
-                .findFirst()
+                .findTop1ByStockIdAndTimestampLessThanEqualOrderByTimestampDesc(request.getStockId(), entryDate)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CANDLE_DATA_NOT_FOUND));
 
         Double entryPrice = latestOhlcv.getClose();


### PR DESCRIPTION
## 🚀 개요
패턴 적용 시 해당 종목의 진입 시점의 정보를 저장하도록 추가

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #57 

## ⏳ 작업 내용
- PatternApply 엔티티에 entryDate, entryPrice 필드 추가
- 패턴 적용 시 entryPrice 자동 조회 및 저장 로직 구현
- DTO 수정

## 📸 스크린샷
<img width="388" height="252" alt="image" src="https://github.com/user-attachments/assets/96fd2333-d9c7-4f0f-8814-0e1323fc918d" />

## 📝 참고 사항
- 기존 detectFrom 필드를 명확성을 위해 entryDate로 변경 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 진입 시점(entryDate)과 진입 가격(entryPrice) 정보를 패턴 적용 결과에 추가하여 더 상세한 정보를 제공합니다.
  * 특정 시점 이전의 최신 주식 시세 데이터를 조회하는 기능이 추가되었습니다.

* **버그 수정**
  * 기존의 감지 시작일(detectFrom) 필드를 진입 시점(entryDate)으로 변경하여 용어를 명확히 하였습니다.

* **기타**
  * 알림 설정 시 사용자 검증이 일시적으로 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->