### PR TITLE
[REFACTOR] 명확성을 위해 'entryDate'의 이름을 'entryAt' 으로 변경 #57

### DIFF
--- a/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyRequestDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyRequestDTO.java
@@ -16,7 +16,7 @@ public class PatternApplyRequestDTO {
     public static class PatternApplyDTO {
         private Long patternId; // 패턴 아이디
         private Long stockId; // 종목 아이디
-        private LocalDateTime entryDate; // 진입 시점 (감지 시작일)
+        private LocalDateTime entryAt; // 진입 시점 (감지 시작일)
     }
 }
 

--- a/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyResponseDTO.java
@@ -27,7 +27,7 @@ public class PatternApplyResponseDTO {
     public static class PatternApplyResultDTO {
         private Long patternApplyId;
         private Boolean isAlertEnabled;
-        private LocalDateTime entryDate;
+        private LocalDateTime entryAt;
         private Double entryPrice;
     }
     // 알림 토글

--- a/src/main/java/com/synergyx/trading/model/PatternApply.java
+++ b/src/main/java/com/synergyx/trading/model/PatternApply.java
@@ -41,8 +41,8 @@ public class PatternApply extends BaseEntity {
     private Boolean isAlertEnabled;
 
     // 진입 시점 (감지 시작일)
-    @Column(name = "entry_date", nullable = false)
-    private LocalDateTime entryDate;
+    @Column(name = "entry_at", nullable = false)
+    private LocalDateTime entryAt;
 
     // 진입 당시 가격
     @Column(name = "entry_price", nullable = false)

--- a/src/main/java/com/synergyx/trading/repository/StockOhlcvRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/StockOhlcvRepository.java
@@ -40,7 +40,7 @@ public interface StockOhlcvRepository extends JpaRepository<StockOhlcv, Long> {
     // 기간별 조회 (정렬 포함)
     List<StockOhlcv> findByStockIdAndTimestampBetweenOrderByTimestampAsc(Long stockId, LocalDateTime start, LocalDateTime end);
 
-    // entryDate (포함) 이전의 가장 최근의 종가 조회
-    Optional<StockOhlcv> findTop1ByStockIdAndTimestampLessThanEqualOrderByTimestampDesc(Long stockId, LocalDateTime entryDate);
+    // entryAt (포함) 이전의 가장 최근의 종가 조회
+    Optional<StockOhlcv> findTop1ByStockIdAndTimestampLessThanEqualOrderByTimestampDesc(Long stockId, LocalDateTime entryAt);
 
 }

--- a/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyServiceImpl.java
@@ -39,13 +39,13 @@ public class PatternApplyServiceImpl implements PatternApplyService {
         Stock stock = stockRepository.findById(request.getStockId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.STOCK_NOT_FOUND));
 
-        LocalDateTime entryDate = request.getEntryDate() != null
-               ? request.getEntryDate()
+        LocalDateTime entryAt = request.getEntryAt() != null
+               ? request.getEntryAt()
                 : LocalDateTime.now();  // 감지 시작일이 null이면 현재 시간으로 대체
 
         // 매수 가격 조회
         StockOhlcv latestOhlcv = stockOhlcvRepository
-                .findTop1ByStockIdAndTimestampLessThanEqualOrderByTimestampDesc(request.getStockId(), entryDate)
+                .findTop1ByStockIdAndTimestampLessThanEqualOrderByTimestampDesc(request.getStockId(), entryAt)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CANDLE_DATA_NOT_FOUND));
 
         Double entryPrice = latestOhlcv.getClose();
@@ -55,7 +55,7 @@ public class PatternApplyServiceImpl implements PatternApplyService {
                 .stock(stock)
                 .user(user)
                 .isAlertEnabled(false)
-                .entryDate(entryDate)
+                .entryAt(entryAt)
                 .entryPrice(entryPrice)
                 .build();
 
@@ -64,7 +64,7 @@ public class PatternApplyServiceImpl implements PatternApplyService {
         return PatternApplyResponseDTO.PatternApplyResultDTO.builder()
                 .patternApplyId(saved.getId())
                 .isAlertEnabled(saved.getIsAlertEnabled())
-                .entryDate(saved.getEntryDate())
+                .entryAt(saved.getEntryAt())
                 .entryPrice(saved.getEntryPrice())
                 .build();
     }
@@ -75,8 +75,8 @@ public class PatternApplyServiceImpl implements PatternApplyService {
     public PatternApplyResponseDTO.PatternApplyToggleDTO toggleNotification(Long userId, Long patternApplyId) {
 
         // 사용자 조회
-//        User user = userRepository.findById(userId)
-//                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 패턴 적용 정보 조회
         PatternApply patternApply = patternApplyRepository.findById(patternApplyId)


### PR DESCRIPTION
## 🚀 개요
명확성을 위해 'entryDate'의 이름을 'entryAt'로 변경

## 📌 관련 이슈
- Closes #57 

## ⏳ 작업 내용
- 명확성을 위해 'entryDate'의 이름을 'entryAt'로 변경했습니다.

## 📸 스크린샷
<img width="402" height="252" alt="image" src="https://github.com/user-attachments/assets/97bacebb-c40d-4dd0-9e23-fa05c8187027" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 여러 화면에서 표시되는 필드명이 기존의 entryDate에서 entryAt으로 변경되었습니다.  
  * 관련된 날짜 및 시간 정보가 entryAt으로 일관되게 표기됩니다.  
* **Bug Fixes**
  * 일부 화면에서 알림 토글 기능이 정상적으로 동작하도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->