### PR TITLE
[FEAT] 종목-패턴 상세 조회 구현 #62

### DIFF
--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
@@ -29,6 +29,7 @@ public enum SuccessStatus implements BaseCode {
     SUCCESS_PATTERN_NOTIFICATION_TOGGLE(HttpStatus.OK, "PATTERN200", "패턴 알림 설정이 변경되었습니다."),
     SUCCESS_PATTERN_APPLY_UPDATE(HttpStatus.OK, "PATTERN200", "패턴 적용 정보가 수정되었습니다."),
     SUCCESS_PATTERN_APPLY_UNLINK(HttpStatus.OK, "PATTERN200", "패턴 적용이 해제되었습니다."),
+    SUCCESS_PATTERN_APPLY_DETAIL(HttpStatus.OK,"PATTERN200", "종목-패턴 적용 상세 조회 성공"),
 
     // 백테스팅
     SUCCESS_BACKTEST_EXECUTE(HttpStatus.OK, "BACKTEST200", "백테스트가 실행되었습니다."),

--- a/src/main/java/com/synergyx/trading/controller/PatternApplyController.java
+++ b/src/main/java/com/synergyx/trading/controller/PatternApplyController.java
@@ -8,6 +8,8 @@ import com.synergyx.trading.service.patternApplyService.PatternApplyCommandServi
 import com.synergyx.trading.service.patternApplyService.PatternApplyQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -42,7 +44,7 @@ public class PatternApplyController {
     @Operation(summary = "패턴 알림 토글", description = "패턴 알림을 토글합니다.")
     @PatchMapping("/{patternApplyId}/notification")
     public ResponseEntity<?>toggleNotification(
-            @PathVariable Long patternApplyId) {
+            @PathVariable @Valid @Positive Long patternApplyId) {
         PatternApplyResponseDTO.PatternApplyToggleDTO response =
                 patternApplyCommandService.toggleNotification(TEMP_USER_ID, patternApplyId);
         return ResponseEntity.ok(ApiResponse.onSuccess(

--- a/src/main/java/com/synergyx/trading/controller/PatternApplyController.java
+++ b/src/main/java/com/synergyx/trading/controller/PatternApplyController.java
@@ -4,7 +4,8 @@ import com.synergyx.trading.apiPayload.ApiResponse;
 import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
 import com.synergyx.trading.dto.patternApply.PatternApplyRequestDTO;
 import com.synergyx.trading.dto.patternApply.PatternApplyResponseDTO;
-import com.synergyx.trading.service.patternApplyService.PatternApplyService;
+import com.synergyx.trading.service.patternApplyService.PatternApplyCommandService;
+import com.synergyx.trading.service.patternApplyService.PatternApplyQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,8 @@ public class PatternApplyController {
     // 임시 userId
     private static final Long TEMP_USER_ID = 1L;
 
-    private final PatternApplyService patternApplyService;
+    private final PatternApplyCommandService patternApplyCommandService;
+    private final PatternApplyQueryService patternApplyQueryService;
 
     // 패턴 적용
     @Operation(summary = "패턴 적용", description = "패턴을 종목에 적용합니다.")
@@ -28,7 +30,7 @@ public class PatternApplyController {
     public ResponseEntity<?> applyPattern(
             @RequestBody PatternApplyRequestDTO.PatternApplyDTO request) {
         PatternApplyResponseDTO.PatternApplyResultDTO response =
-                patternApplyService.applyPattern(TEMP_USER_ID, request);
+                patternApplyCommandService.applyPattern(TEMP_USER_ID, request);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 response,
                 SuccessStatus.SUCCESS_PATTERN_APPLY.getCode(),
@@ -42,7 +44,7 @@ public class PatternApplyController {
     public ResponseEntity<?>toggleNotification(
             @PathVariable Long patternApplyId) {
         PatternApplyResponseDTO.PatternApplyToggleDTO response =
-                patternApplyService.toggleNotification(TEMP_USER_ID, patternApplyId);
+                patternApplyCommandService.toggleNotification(TEMP_USER_ID, patternApplyId);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 response,
                 SuccessStatus.SUCCESS_PATTERN_NOTIFICATION_TOGGLE.getCode(),
@@ -56,7 +58,7 @@ public class PatternApplyController {
     public ResponseEntity<?> updatePatternApply(
             @PathVariable Long patternApplyId,
             @RequestBody PatternApplyRequestDTO.PatternApplyUpdateDTO request) {
-                patternApplyService.updatePatternApply(TEMP_USER_ID, patternApplyId, request);
+                patternApplyCommandService.updatePatternApply(TEMP_USER_ID, patternApplyId, request);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 SuccessStatus.SUCCESS_PATTERN_APPLY_UPDATE.getCode(),
                 SuccessStatus.SUCCESS_PATTERN_APPLY_UPDATE.getMessage()
@@ -67,11 +69,27 @@ public class PatternApplyController {
     @Operation(summary = "패턴 적용 해제", description = "종목에 적용된 패턴을 해제합니다.")
     @DeleteMapping("/{patternApplyId}")
     public ResponseEntity<?> deletePatternApply(@PathVariable Long patternApplyId) {
-        patternApplyService.deletePatternApply(TEMP_USER_ID, patternApplyId);
+        patternApplyCommandService.deletePatternApply(TEMP_USER_ID, patternApplyId);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 SuccessStatus.SUCCESS_PATTERN_APPLY_UNLINK.getCode(),
                 SuccessStatus.SUCCESS_PATTERN_APPLY_UNLINK.getMessage()
         ));
     }
+
+    // 종목-패턴 상세 조회
+    @Operation(summary = "종목-패턴 상세 조회", description = "특정 종목에 적용된 패턴과 관련된 상세 정보를 조회합니다.")
+    @GetMapping("/stocks/{stockId}")
+    public ResponseEntity<?> getPatternApplyDetailByStockId(
+            @PathVariable Long stockId
+    ) {
+        PatternApplyResponseDTO.PatternApplyDetailDTO response =
+                patternApplyQueryService.getPatternApplyDetail(TEMP_USER_ID, stockId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                response,
+                SuccessStatus.SUCCESS_PATTERN_APPLY_DETAIL.getCode(),
+                SuccessStatus.SUCCESS_PATTERN_APPLY_DETAIL.getMessage()
+        ));
+    }
+
 }
 

--- a/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/patternApply/PatternApplyResponseDTO.java
@@ -5,14 +5,16 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class PatternApplyResponseDTO {
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    // 패턴 상세 화면 -> 적용된 패턴 목록
+    // [패턴 상세 화면] 적용된 종목 목록
     public static class PatternApplyListDTO {
         private Long applyId;
         private String patternName;
@@ -38,6 +40,59 @@ public class PatternApplyResponseDTO {
     public static class PatternApplyToggleDTO  {
         private Long patternApplyId;
         private Boolean isAlertEnabled;
+    }
+    // [관심 종목 상세 화면] 종목 정보, 패턴 정보, 최근 백테스팅 결과
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PatternApplyDetailDTO {
+        private Long patternApplyId;
+
+        // 종목 정보
+        private StockDTO stock;
+
+        // 패턴 정보
+        private PatternDTO pattern;
+
+        // 최근 백테스트 결과
+        private BacktestResultDTO backtestResult;
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class StockDTO {
+            private Long stockId;
+            private String stockName;
+            private String stockImage;
+        }
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class PatternDTO {
+            private Long patternId;
+            private List<Double> points;
+            private Double tolerance;
+            private Integer periodValue;
+            private String periodUnit;
+        }
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class BacktestResultDTO {
+            private Long backtestId;
+            private LocalDate executedAt;
+            private Integer matchedCount;
+            private LocalDate startDate;
+            private LocalDate endDate;
+            private Double winRate;
+            private Double averageReturn;
+            private Double maxReturn;
+            private LocalDate maxReturnDate;
+        }
     }
 }
 

--- a/src/main/java/com/synergyx/trading/model/Backtest.java
+++ b/src/main/java/com/synergyx/trading/model/Backtest.java
@@ -6,7 +6,13 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "backtest")
+@Table(
+        name = "backtest",
+        indexes = @Index(
+                name = "idx_pattern_stock_user_exec",
+                columnList = "pattern_id, stock_id, user_id, executed_at"
+        )
+)
 @Getter
 @Setter
 @Builder

--- a/src/main/java/com/synergyx/trading/repository/BacktestRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/BacktestRepository.java
@@ -15,6 +15,16 @@ public interface BacktestRepository extends JpaRepository<Backtest, Long> {
     // 실행 날짜 동일할 경우, 아이디 내림차순.
     Optional<Backtest> findTopByUserIdAndPatternIdOrderByExecutedAtDescIdDesc(Long userId, Long patternId);
 
+    // 특정 패턴에 대한 모든 백테스팅 삭제
     void deleteAllByPattern(Pattern pattern);
+
+    // 사용자의 백테스팅 목록 조회
     Page<Backtest> findByUserId(Long userId, Pageable pageable);
+
+    // 사용자 + 종목 + 패턴 조합으로 실행한 가장 최근 백테스트 1건 조회
+    Optional<Backtest> findTop1ByPatternIdAndStockIdAndUserIdOrderByExecutedAtDesc(
+            Long patternId,
+            Long stockId,
+            Long userId
+    );
 }

--- a/src/main/java/com/synergyx/trading/repository/PatternApplyRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/PatternApplyRepository.java
@@ -6,9 +6,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PatternApplyRepository extends JpaRepository<PatternApply, Long> {
+    // 패턴 적용 목록 조회
     List<PatternApply> findByUserIdAndPatternId(Long userId, Long patternId);
+    // 패턴 삭제
     void deleteAllByPattern(Pattern pattern);
+    // 종목 아이디로 종목-패턴 상세 조회
+    Optional<PatternApply> findByUserIdAndStockId(Long userId, Long stockId);
 }

--- a/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyCommandService.java
+++ b/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyCommandService.java
@@ -3,7 +3,7 @@ package com.synergyx.trading.service.patternApplyService;
 import com.synergyx.trading.dto.patternApply.PatternApplyRequestDTO;
 import com.synergyx.trading.dto.patternApply.PatternApplyResponseDTO;
 
-public interface PatternApplyService {
+public interface PatternApplyCommandService {
     // 패턴 적용
     PatternApplyResponseDTO.PatternApplyResultDTO applyPattern(Long userId, PatternApplyRequestDTO.PatternApplyDTO request);
 

--- a/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyCommandServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyCommandServiceImpl.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
-public class PatternApplyServiceImpl implements PatternApplyService {
+public class PatternApplyCommandServiceImpl implements PatternApplyCommandService {
 
     private final PatternRepository patternRepository;
     private final PatternApplyRepository patternApplyRepository;

--- a/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyQueryService.java
+++ b/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyQueryService.java
@@ -1,0 +1,8 @@
+package com.synergyx.trading.service.patternApplyService;
+
+import com.synergyx.trading.dto.patternApply.PatternApplyResponseDTO;
+
+public interface PatternApplyQueryService {
+    // 종목-패턴 상세 조회
+    PatternApplyResponseDTO.PatternApplyDetailDTO getPatternApplyDetail(Long userId, Long stockId);
+}

--- a/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyQueryServiceImpl.java
@@ -33,12 +33,10 @@ public class PatternApplyQueryServiceImpl implements PatternApplyQueryService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PATTERN_APPLY_NOT_FOUND));
 
         // 종목 조회
-        Stock stock = stockRepository.findById(stockId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.STOCK_NOT_FOUND));
+        Stock stock = patternApply.getStock();
 
         // 패턴 조회
-        Pattern pattern = patternRepository.findById(patternApply.getPattern().getId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.PATTERN_NOT_FOUND));
+        Pattern pattern = patternApply.getPattern();
 
         // 최근 백테스트 1건
         Backtest backtest = backtestRepository

--- a/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternApplyService/PatternApplyQueryServiceImpl.java
@@ -1,0 +1,76 @@
+package com.synergyx.trading.service.patternApplyService;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.dto.patternApply.PatternApplyResponseDTO;
+import com.synergyx.trading.model.*;
+import com.synergyx.trading.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PatternApplyQueryServiceImpl implements PatternApplyQueryService {
+
+    private final PatternRepository patternRepository;
+    private final PatternApplyRepository patternApplyRepository;
+    private final UserRepository userRepository;
+    private final BacktestRepository backtestRepository;
+    private final StockRepository stockRepository;
+
+    // 종목-패턴 상세 조회
+    @Override
+    @Transactional(readOnly = true)
+    public PatternApplyResponseDTO.PatternApplyDetailDTO getPatternApplyDetail(Long userId, Long stockId) {
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 패턴 적용 정보 조회
+        PatternApply patternApply = patternApplyRepository.findByUserIdAndStockId(userId, stockId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PATTERN_APPLY_NOT_FOUND));
+
+        // 종목 조회
+        Stock stock = stockRepository.findById(stockId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.STOCK_NOT_FOUND));
+
+        // 패턴 조회
+        Pattern pattern = patternRepository.findById(patternApply.getPattern().getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PATTERN_NOT_FOUND));
+
+        // 최근 백테스트 1건
+        Backtest backtest = backtestRepository
+                .findTop1ByPatternIdAndStockIdAndUserIdOrderByExecutedAtDesc(
+                        pattern.getId(), stock.getId(), user.getId()
+                ).orElse(null);
+
+        return PatternApplyResponseDTO.PatternApplyDetailDTO.builder()
+                .patternApplyId(patternApply.getId())
+                .stock(PatternApplyResponseDTO.PatternApplyDetailDTO.StockDTO.builder()
+                        .stockId(stockId)
+                        .stockName(stock.getName())
+                        .stockImage(stock.getImageUrl())
+                        .build())
+                .pattern(PatternApplyResponseDTO.PatternApplyDetailDTO.PatternDTO.builder()
+                        .patternId(pattern.getId())
+                        .points(pattern.getPoints())
+                        .tolerance(pattern.getTolerance())
+                        .periodValue(pattern.getPeriodValue())
+                        .periodUnit(String.valueOf(pattern.getPeriodUnit()))
+                        .build())
+                .backtestResult(backtest != null ? PatternApplyResponseDTO.PatternApplyDetailDTO.BacktestResultDTO.builder()
+                        .backtestId(backtest.getId())
+                        .executedAt(backtest.getExecutedAt())
+                        .startDate(backtest.getStartDate())
+                        .endDate(backtest.getEndDate())
+                        .matchedCount(backtest.getMatchedCount())
+                        .winRate(backtest.getWinRate())
+                        .averageReturn(backtest.getAverageReturn())
+                        .maxReturn(backtest.getMaxReturn())
+                        .maxReturnDate(backtest.getMaxReturnDate())
+                        .build() : null)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🚀 개요
종목-패턴 상세 조회 API를 구현했습니다.

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #62 

## ⏳ 작업 내용
- 종목-패턴 상세 조회 API 구현
- 서비스, DTO, 컨트롤러 생성

## 📸 스크린샷
<img width="935" height="536" alt="image" src="https://github.com/user-attachments/assets/afb2a10d-87af-42f8-8e63-60ae96c13bc3" />
<img width="968" height="550" alt="image" src="https://github.com/user-attachments/assets/d763bc95-0fff-4f01-a22a-4e900bad44d9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 특정 종목에 대한 패턴 적용 상세 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 패턴 적용 상세 정보는 종목, 패턴, 백테스트 결과 등 다양한 세부 정보를 포함합니다.

* **개선 사항**
  * 패턴 적용 관련 서비스가 명령(Command)과 조회(Query)로 분리되어, 더 명확한 역할로 동작합니다.
  * 패턴 적용 및 백테스트 관련 저장소에 다양한 조회 및 삭제 기능이 추가되어 데이터 관리가 강화되었습니다.
  * 데이터베이스 백테스트 테이블에 복합 인덱스가 추가되어 쿼리 성능이 개선되었습니다.

* **버그 수정**
  * 없음

* **기타**
  * 코드 구조 개선을 위해 서비스 및 클래스 명칭이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->