### PR TITLE
[FEAT] 3M, 1Y, 5Y 캔들 조회 로직 추가 #65

### DIFF
--- a/src/main/java/com/synergyx/trading/controller/KisTestController.java
+++ b/src/main/java/com/synergyx/trading/controller/KisTestController.java
@@ -175,7 +175,7 @@ public class KisTestController {
     }
 
     @Operation(summary = "전체 3M Ohlcv 업데이트 API", description = "3M Ohlcv 값을 가져옵니다.")
-//    @PostMapping("/stocks/ohlcv/3M") // todo: 데이터 이어서 수집해야 함
+//    @PostMapping("/stocks/ohlcv/3M")
     public ResponseEntity<?> update3mOhlcv() {
         try {
             kis1dOhlcvUpdateService.updateOhlcvAll();

--- a/src/main/java/com/synergyx/trading/controller/StockController.java
+++ b/src/main/java/com/synergyx/trading/controller/StockController.java
@@ -51,13 +51,7 @@ public class StockController {
 
     @Operation(
             summary = "종목 캔들 데이터 조회",
-            description = """
-                    `interval` (1D, 1W, 3M, 1Y, 5Y)에 따라 캔들 데이터를 조회합니다.
-                            
-                    ⚠️ 현재 3M, 1Y, 5Y는 임시로 1W 기준 캔들(약 40~50개)을 반환하며,  
-                    추후 실제 데이터 연동 시 캔들 수가 변경될 수 있습니다.
-                    """
-    )// todo:description 수정
+            description = "interval` (1D, 1W, 3M, 1Y, 5Y)에 따라 캔들 데이터를 조회합니다.")
     @GetMapping("/stocks/{stockId}/candles")
     public ResponseEntity<?> getStockCandles(
             @PathVariable Long stockId,

--- a/src/main/java/com/synergyx/trading/converter/StockCandleConverter.java
+++ b/src/main/java/com/synergyx/trading/converter/StockCandleConverter.java
@@ -1,0 +1,25 @@
+package com.synergyx.trading.converter;
+
+import com.synergyx.trading.dto.stockDetail.StockCandleResponseDTO;
+import com.synergyx.trading.model.common.Ohlcv;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class StockCandleConverter {
+
+    public List<StockCandleResponseDTO> toDtoList(List<? extends Ohlcv> ohlcvs) {
+        return ohlcvs.stream()
+                .map(o -> StockCandleResponseDTO.builder()
+                        .time(o.getTimestamp())
+                        .open(o.getOpen())
+                        .close(o.getClose())
+                        .high(o.getHigh())
+                        .low(o.getLow())
+                        .volume(o.getVolume())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/synergyx/trading/enums/CandleInterval.java
+++ b/src/main/java/com/synergyx/trading/enums/CandleInterval.java
@@ -1,5 +1,8 @@
 package com.synergyx.trading.enums;
 
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+
 import java.time.LocalDateTime;
 
 public enum CandleInterval {
@@ -53,6 +56,6 @@ public enum CandleInterval {
                 return interval;
             }
         }
-        throw new IllegalArgumentException("지원하지 않는 interval입니다: " + code);
+        throw new GeneralException(ErrorStatus.INVALID_CANDLE_INTERVAL);
     }
 }

--- a/src/main/java/com/synergyx/trading/model/StockOhlcv1d.java
+++ b/src/main/java/com/synergyx/trading/model/StockOhlcv1d.java
@@ -1,6 +1,7 @@
 package com.synergyx.trading.model;
 
 import com.synergyx.trading.model.common.BaseEntity;
+import com.synergyx.trading.model.common.Ohlcv;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,7 +19,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class StockOhlcv1d extends BaseEntity {
+public class StockOhlcv1d extends BaseEntity implements Ohlcv {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/synergyx/trading/model/StockOhlcv1m.java
+++ b/src/main/java/com/synergyx/trading/model/StockOhlcv1m.java
@@ -1,6 +1,7 @@
 package com.synergyx.trading.model;
 
 import com.synergyx.trading.model.common.BaseEntity;
+import com.synergyx.trading.model.common.Ohlcv;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,7 +19,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class StockOhlcv1m extends BaseEntity {
+public class StockOhlcv1m extends BaseEntity implements Ohlcv {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/synergyx/trading/model/common/Ohlcv.java
+++ b/src/main/java/com/synergyx/trading/model/common/Ohlcv.java
@@ -1,0 +1,17 @@
+package com.synergyx.trading.model.common;
+
+import java.time.LocalDateTime;
+
+public interface Ohlcv {
+    LocalDateTime getTimestamp();
+
+    Double getOpen();
+
+    Double getClose();
+
+    Double getHigh();
+
+    Double getLow();
+
+    Long getVolume();
+}

--- a/src/main/java/com/synergyx/trading/repository/StockOhlcv1dRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/StockOhlcv1dRepository.java
@@ -4,6 +4,7 @@ import com.synergyx.trading.model.StockOhlcv1d;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface StockOhlcv1dRepository extends JpaRepository<StockOhlcv1d, Long> {
@@ -13,4 +14,7 @@ public interface StockOhlcv1dRepository extends JpaRepository<StockOhlcv1d, Long
 
     // 중복 확인
     boolean existsByStockIdAndTimestamp(Long stockId, LocalDateTime timestamp);
+
+    // 상위 63개 ohlcv 조회 (약 3개월)
+    List<StockOhlcv1d> findTop63ByStockIdOrderByTimestampDesc(Long stockId);
 }

--- a/src/main/java/com/synergyx/trading/repository/StockOhlcv1mRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/StockOhlcv1mRepository.java
@@ -2,13 +2,18 @@ package com.synergyx.trading.repository;
 
 import com.synergyx.trading.model.StockOhlcv1m;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface StockOhlcv1mRepository extends JpaRepository<StockOhlcv1m, Long> {
 
     Optional<StockOhlcv1m> findByStock_IdAndTimestamp(Long stockId, LocalDateTime timestamp);
+
+    // 상위 12개 ohlcv 조회 (1년 치)
+    List<StockOhlcv1m> findTop12ByStockIdOrderByTimestampDesc(Long stockId);
+
+    // 상위 60개 ohlcv 조회 (5년 치)
+    List<StockOhlcv1m> findTop60ByStockIdOrderByTimestampDesc(Long stockId);
 }

--- a/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryServiceImpl.java
@@ -33,11 +33,7 @@ public class StockCandleQueryServiceImpl implements StockCandleQueryService {
     @Transactional(readOnly = true)
     public List<StockCandleResponseDTO> getCandles(Long stockId, String intervalStr) {
 
-        // todo: 3m, 1y, 5y 데이터 연동 전까지는 1w로 대체. 추후 삭제
-        String effectiveInterval = switch (intervalStr.toUpperCase()) {
-            case "3M", "1Y", "5Y" -> "1W";
-            default -> intervalStr;
-        };
+        String effectiveInterval = intervalStr.toUpperCase();
 
         CandleInterval interval = CandleInterval.fromCode(effectiveInterval);
 

--- a/src/main/java/com/synergyx/trading/service/stockService/candle/strategy/FiveYearCompressionStrategy.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/candle/strategy/FiveYearCompressionStrategy.java
@@ -1,0 +1,48 @@
+package com.synergyx.trading.service.stockService.candle.strategy;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.converter.StockCandleConverter;
+import com.synergyx.trading.dto.stockDetail.StockCandleResponseDTO;
+import com.synergyx.trading.enums.CandleInterval;
+import com.synergyx.trading.model.StockOhlcv1m;
+import com.synergyx.trading.repository.StockOhlcv1mRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * [5Y] 5년 캔들 전략
+ * <p>
+ * - interval = CandleInterval.FIVE_YEARS
+ * - 최근 60개월 간의 월봉 데이터 조회 (60개 고정)
+ * - 시간 역순으로 조회 후 , 시간순 정렬
+ */
+@Component
+@RequiredArgsConstructor
+public class FiveYearCompressionStrategy implements CandleCompressionStrategy {
+
+    private final StockOhlcv1mRepository stockOhlcv1mRepository;
+    private final StockCandleConverter stockCandleConverter;
+
+    @Override
+    public boolean supports(CandleInterval interval) {
+        return interval == CandleInterval.FIVE_YEARS;
+    }
+
+    @Override
+    public List<StockCandleResponseDTO> compress(Long stockId) {
+
+        List<StockOhlcv1m> candles = stockOhlcv1mRepository.findTop60ByStockIdOrderByTimestampDesc(stockId);
+
+        if (candles == null || candles.isEmpty()) {
+            throw new GeneralException(ErrorStatus.CANDLE_DATA_NOT_FOUND);
+        }
+
+        Collections.reverse(candles);
+
+        return stockCandleConverter.toDtoList(candles);
+    }
+}

--- a/src/main/java/com/synergyx/trading/service/stockService/candle/strategy/OneYearCompressionStrategy.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/candle/strategy/OneYearCompressionStrategy.java
@@ -1,0 +1,48 @@
+package com.synergyx.trading.service.stockService.candle.strategy;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.converter.StockCandleConverter;
+import com.synergyx.trading.dto.stockDetail.StockCandleResponseDTO;
+import com.synergyx.trading.enums.CandleInterval;
+import com.synergyx.trading.model.StockOhlcv1m;
+import com.synergyx.trading.repository.StockOhlcv1mRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * [1Y] 1년 캔들 전략
+ * <p>
+ * - interval = CandleInterval.ONE_YEAR
+ * - 최근 12개월 간의 월봉 데이터 조회 (12개 고정)
+ * - 시간 역순으로 조회 후, 시간순 정렬
+ */
+@Component
+@RequiredArgsConstructor
+public class OneYearCompressionStrategy implements CandleCompressionStrategy {
+
+    private final StockOhlcv1mRepository stockOhlcv1mRepository;
+    private final StockCandleConverter stockCandleConverter;
+
+    @Override
+    public boolean supports(CandleInterval interval) {
+        return interval == CandleInterval.ONE_YEAR;
+    }
+
+    @Override
+    public List<StockCandleResponseDTO> compress(Long stockId) {
+
+        List<StockOhlcv1m> candles = stockOhlcv1mRepository.findTop12ByStockIdOrderByTimestampDesc(stockId);
+
+        if (candles == null || candles.isEmpty()) {
+            throw new GeneralException(ErrorStatus.CANDLE_DATA_NOT_FOUND);
+        }
+
+        Collections.reverse(candles);
+
+        return stockCandleConverter.toDtoList(candles);
+    }
+}

--- a/src/main/java/com/synergyx/trading/service/stockService/candle/strategy/ThreeMonthCompressionStrategy.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/candle/strategy/ThreeMonthCompressionStrategy.java
@@ -1,0 +1,48 @@
+package com.synergyx.trading.service.stockService.candle.strategy;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.converter.StockCandleConverter;
+import com.synergyx.trading.dto.stockDetail.StockCandleResponseDTO;
+import com.synergyx.trading.enums.CandleInterval;
+import com.synergyx.trading.model.StockOhlcv1d;
+import com.synergyx.trading.repository.StockOhlcv1dRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * [3M] 3개월 캔들 전략
+ * <p>
+ * - interval = CandleInterval.THREE_MONTHS
+ * - 최근 3개월 간의 일봉 데이터 조회 (63 (21*3) 개 고정)
+ * - 시간 역순으로 조회 후, 시간순 정렬
+ */
+@Component
+@RequiredArgsConstructor
+public class ThreeMonthCompressionStrategy implements CandleCompressionStrategy {
+
+    private final StockOhlcv1dRepository stockOhlcv1dRepository;
+    private final StockCandleConverter stockCandleConverter;
+
+    @Override
+    public boolean supports(CandleInterval interval) {
+        return interval == CandleInterval.THREE_MONTHS;
+    }
+
+    @Override
+    public List<StockCandleResponseDTO> compress(Long stockId) {
+
+        List<StockOhlcv1d> candles = stockOhlcv1dRepository.findTop63ByStockIdOrderByTimestampDesc(stockId);
+
+        if (candles == null || candles.isEmpty()) {
+            throw new GeneralException(ErrorStatus.CANDLE_DATA_NOT_FOUND);
+        }
+
+        Collections.reverse(candles);
+
+        return stockCandleConverter.toDtoList(candles);
+    }
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
3M, 1Y, 5Y 캔들 조회 로직을 구현했습니다.

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #65

## ⏳ 작업 내용
- 3M : 63개의 일봉 반환 (21*3)
- 1Y : 12개의 월봉 반환
- 5Y : 60개의 월봉 반환 (12*5)

## 📸 스크린샷
- 
<img width="761" height="664" alt="스크린샷 2025-08-04 오전 12 57 40" src="https://github.com/user-attachments/assets/e52dd9f8-611a-4281-85c9-8afa71435a7a" />

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 3개월, 1년, 5년 캔들 데이터 조회를 위한 새로운 압축 전략이 추가되었습니다.
  * 다양한 캔들 데이터 변환 및 응답을 위한 변환기와 인터페이스가 도입되었습니다.

* **Bug Fixes**
  * 캔들 구간 코드 변환 시 예외 처리 방식이 개선되었습니다.

* **Documentation**
  * 일부 엔드포인트의 설명이 간소화되었습니다.

* **Refactor**
  * 내부 데이터 모델이 인터페이스를 구현하도록 구조가 개선되었습니다.
  * 불필요한 임시 매핑 로직이 제거되었습니다.

* **Chores**
  * 리포지토리에 캔들 데이터 조회 메소드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->