### PR TITLE
[FEAT] 감정 투자 일기 api 구현 #67

### DIFF
--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
@@ -50,6 +50,10 @@ public enum ErrorStatus implements BaseErrorCode {
     FCM_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "NOTIFICATION400", "FCM 토큰이 존재하지 않아 알림을 전송할 수 없습니다."),
     INVALID_NOTIFICATION_TYPE(HttpStatus.BAD_REQUEST, "NOTIFICATION4001", "유효하지 않은 알림 타입입니다."),
 
+    // 감정 투자 일기 관련 예외 처리
+    INVALID_CONTENT(HttpStatus.BAD_REQUEST, "DIARY400", "일기 내용이 비어있습니다."),
+    FASTAPI_ANALYSIS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DIARY502", "FastAPI 감정 분석 서버 호출에 실패했습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
@@ -45,6 +45,9 @@ public enum SuccessStatus implements BaseCode {
     // 사용자
     SUCCESS_FCM_TOKEN_UPDATED(HttpStatus.OK, "FCM200", "FCM 토큰이 성공적으로 저장되었습니다."),
 
+    // 감정 투자 일기
+    SUCCESS_WRITE_EMOTION_DIARY(HttpStatus.OK, "DIARY200", "감정 투자 일기 작성 성공"),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/synergyx/trading/config/WebClientConfig.java
+++ b/src/main/java/com/synergyx/trading/config/WebClientConfig.java
@@ -19,7 +19,7 @@ public class WebClientConfig {
     @Bean
     public WebClient fastApiWebClient() {
         return WebClient.builder()
-                .baseUrl("http://localhost:8000") // TODO: FastAPI 주소
+                .baseUrl("http://localhost:8000")
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }

--- a/src/main/java/com/synergyx/trading/controller/EmotionDiaryController.java
+++ b/src/main/java/com/synergyx/trading/controller/EmotionDiaryController.java
@@ -1,0 +1,50 @@
+package com.synergyx.trading.controller;
+
+import com.synergyx.trading.apiPayload.ApiResponse;
+import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
+import com.synergyx.trading.dto.emotionDiary.EmotionDiaryRequestDTO;
+import com.synergyx.trading.dto.emotionDiary.EmotionDiaryResponseDTO;
+import com.synergyx.trading.service.emotionDiaryService.EmotionDiaryCommandService;
+import com.synergyx.trading.service.emotionDiaryService.EmotionDiaryQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/diaries")
+@Tag(name = "감정 투자 일기 API", description = "감정 투자 일기 관련 API 입니다.")
+public class EmotionDiaryController {
+
+    // 임시 userId
+    private static final Long TEMP_USER_ID = 1L;
+
+    private final EmotionDiaryCommandService emotionDiaryCommandService;
+    private final EmotionDiaryQueryService emotionDiaryQueryService;
+
+    // 감정 투자 일기 작성
+    @Operation(summary = "감정 투자 일기 작성", description = "감정 투자 일기를 작성합니다.")
+    @PostMapping
+    public ResponseEntity<?> writeDiary(
+           @Valid @RequestBody EmotionDiaryRequestDTO request) {
+        EmotionDiaryResponseDTO.EmotionDiaryDTO result = emotionDiaryCommandService.writeDiary(TEMP_USER_ID, request);
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                result,
+                SuccessStatus.SUCCESS_WRITE_EMOTION_DIARY.getCode(),
+                SuccessStatus.SUCCESS_WRITE_EMOTION_DIARY.getMessage()
+        ));
+    }
+
+    // 감정 투자 일기 전체 조회
+    @Operation(summary = "감정 투자 일기 목록 조회", description = "감정 투자 일기 전체를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<?> getEmotionDiaryList() {
+        List<EmotionDiaryResponseDTO.EmotionDiaryDTO> result = emotionDiaryQueryService.getEmotionDiaryList(TEMP_USER_ID);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
+}

--- a/src/main/java/com/synergyx/trading/converter/EmotionListConverter.java
+++ b/src/main/java/com/synergyx/trading/converter/EmotionListConverter.java
@@ -27,7 +27,7 @@ public class EmotionListConverter implements AttributeConverter<List<String>, St
     @Override
     public List<String> convertToEntityAttribute(String dbData) {
         try {
-            return mapper.readValue(dbData, new TypeReference<List<String>>() {});
+            return mapper.readValue(dbData, new TypeReference<>() {});
         } catch (Exception e) {
             return new ArrayList<>();
         }

--- a/src/main/java/com/synergyx/trading/converter/EmotionListConverter.java
+++ b/src/main/java/com/synergyx/trading/converter/EmotionListConverter.java
@@ -1,0 +1,35 @@
+package com.synergyx.trading.converter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Converter
+public class EmotionListConverter implements AttributeConverter<List<String>, String> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    // List<String> → JSON 문자열로 변환
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (Exception e) {
+            return "[]";
+        }
+    }
+
+    // JSON 문자열 → List<String> 으로 역변환
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        try {
+            return mapper.readValue(dbData, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/com/synergyx/trading/dto/emotionDiary/EmotionDiaryRequestDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/emotionDiary/EmotionDiaryRequestDTO.java
@@ -1,0 +1,15 @@
+package com.synergyx.trading.dto.emotionDiary;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 감정 일기 생성
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmotionDiaryRequestDTO {
+    private String content; // 일기 원문
+}

--- a/src/main/java/com/synergyx/trading/dto/emotionDiary/EmotionDiaryResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/emotionDiary/EmotionDiaryResponseDTO.java
@@ -1,0 +1,54 @@
+package com.synergyx.trading.dto.emotionDiary;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class EmotionDiaryResponseDTO {
+
+    // FastAPI에서 받은 응답을 감싸는 Wrapper DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmotionDiaryWrapperResponseDTO {
+
+        // camelCase로 매핑
+        @JsonProperty("is_success")
+        private boolean isSuccess;
+
+        private String code;
+        private String message;
+        private EmotionDiaryResponseDTO.EmotionAnalysisResultDTO data;
+    }
+
+    // 감정 일기 생성, 전체 목록 조회
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class EmotionDiaryDTO {
+        private Long diaryId; // 일기 id
+        private String content; // 원문
+        private List<String> emotion; // 감정
+        private String summary; // 요약
+        private String feedback; // 조언
+        private LocalDateTime createdAt; // 작성 일시
+    }
+
+    // 감정 분석 결과
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class EmotionAnalysisResultDTO  {
+        private List<String> emotion; // 감정
+        private String summary; // 요약
+        private String feedback; // 조언
+    }
+}

--- a/src/main/java/com/synergyx/trading/model/EmotionDiary.java
+++ b/src/main/java/com/synergyx/trading/model/EmotionDiary.java
@@ -1,0 +1,45 @@
+package com.synergyx.trading.model;
+
+import com.synergyx.trading.converter.EmotionListConverter;
+import com.synergyx.trading.model.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.List;
+
+@Entity
+@Table(name = "emotion_diary")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmotionDiary extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 사용자 테이블 매핑
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 일기 원문
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    // 감정
+    @Column(name = "emotion", columnDefinition = "TEXT", nullable = false)
+    @Convert(converter = EmotionListConverter.class)
+    private List<String> emotion;
+
+    // 요약
+    @Column(name = "summary", columnDefinition = "TEXT", nullable = false)
+    private String summary;
+
+    // 조언
+    @Column(name = "feedback", columnDefinition = "TEXT", nullable = false)
+    private String feedback;
+
+}
+

--- a/src/main/java/com/synergyx/trading/repository/EmotionDiaryRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/EmotionDiaryRepository.java
@@ -1,0 +1,12 @@
+package com.synergyx.trading.repository;
+
+import com.synergyx.trading.model.EmotionDiary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface EmotionDiaryRepository extends JpaRepository<EmotionDiary, Long> {
+    List<EmotionDiary> findAllByUserIdOrderByCreatedAtAsc(Long userId);
+}

--- a/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryCommandService.java
+++ b/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryCommandService.java
@@ -1,0 +1,9 @@
+package com.synergyx.trading.service.emotionDiaryService;
+
+import com.synergyx.trading.dto.emotionDiary.EmotionDiaryResponseDTO;
+import com.synergyx.trading.dto.emotionDiary.EmotionDiaryRequestDTO;
+
+public interface EmotionDiaryCommandService {
+    // 감정 투자 일기 작성
+    EmotionDiaryResponseDTO.EmotionDiaryDTO writeDiary(Long userId, EmotionDiaryRequestDTO dto);
+}

--- a/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryCommandServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryCommandServiceImpl.java
@@ -1,0 +1,73 @@
+package com.synergyx.trading.service.emotionDiaryService;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.dto.emotionDiary.EmotionDiaryRequestDTO;
+import com.synergyx.trading.dto.emotionDiary.EmotionDiaryResponseDTO;
+import com.synergyx.trading.model.*;
+import com.synergyx.trading.repository.*;
+//import com.synergyx.trading.service.emotionDiaryService.client.EmotionDiaryClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionDiaryCommandServiceImpl implements  EmotionDiaryCommandService {
+
+    private final EmotionDiaryRepository emotionDiaryRepository;
+    private final UserRepository userRepository;
+//    private final EmotionDiaryClientService emotionDiaryClientService;
+
+    // 감정 투자 일기 생성
+    @Override
+    @Transactional
+    public EmotionDiaryResponseDTO.EmotionDiaryDTO writeDiary(Long userId, EmotionDiaryRequestDTO dto) {
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 빈 칸 예외 처리
+        if (dto.getContent() == null || dto.getContent().trim().isEmpty()) {
+            throw new GeneralException(ErrorStatus.INVALID_CONTENT);
+        }
+
+        // TODO: fastAPI 연결 후 주석 삭제
+//        EmotionDiaryResponseDTO.EmotionAnalysisResultDTO result = emotionDiaryClientService.callEmotionDiaryAPI(dto.getContent());
+//
+//        EmotionDiary diary = emotionDiaryRepository.save(
+//                EmotionDiary.builder()
+//                        .user(user)
+//                        .content(dto.getContent())
+//                        .emotion(result.getEmotion())
+//                        .summary(result.getSummary())
+//                        .feedback(result.getFeedback())
+//                        .build()
+//        );
+
+        // TODO: fastAPI 연결 후 삭제
+        // 목데이터
+        EmotionDiary diary = emotionDiaryRepository.save(
+                EmotionDiary.builder()
+                        .user(user)
+                        .content(dto.getContent())
+                        .emotion(List.of("기쁨", "만족", "뿌듯함"))
+                        .summary("주가 급등으로 인한 큰 수익과 긍정적인 감정 표현")
+                        .feedback("수익 실현 축하드려요! 앞으로도 꾸준한 리스크 관리와 분산 투자를 유지해보세요.")
+                        .build()
+        );
+
+        return EmotionDiaryResponseDTO.EmotionDiaryDTO.builder()
+                .diaryId(diary.getId())
+                .content(diary.getContent())
+                .emotion(diary.getEmotion())
+                .summary(diary.getSummary())
+                .feedback(diary.getFeedback())
+                .createdAt(diary.getCreatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryQueryService.java
+++ b/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryQueryService.java
@@ -1,0 +1,8 @@
+package com.synergyx.trading.service.emotionDiaryService;
+import com.synergyx.trading.dto.emotionDiary.EmotionDiaryResponseDTO;
+import java.util.List;
+
+public interface EmotionDiaryQueryService {
+    // 감정 투자 일기 전체 목록 조회
+    List<EmotionDiaryResponseDTO.EmotionDiaryDTO> getEmotionDiaryList(Long userId);
+}

--- a/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryQueryServiceImpl.java
@@ -1,0 +1,43 @@
+package com.synergyx.trading.service.emotionDiaryService;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.dto.emotionDiary.EmotionDiaryResponseDTO;
+import com.synergyx.trading.model.*;
+import com.synergyx.trading.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionDiaryQueryServiceImpl implements EmotionDiaryQueryService {
+
+    private final UserRepository userRepository;
+    private final EmotionDiaryRepository emotionDiaryRepository;
+
+    // 패턴 목록 조회
+    @Override
+    @Transactional(readOnly = true)
+    public List<EmotionDiaryResponseDTO.EmotionDiaryDTO> getEmotionDiaryList(Long userId) {
+
+        // 유저 존재 여부 확인
+        if (!userRepository.existsById(userId)) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
+
+        List<EmotionDiary> diaries = emotionDiaryRepository.findAllByUserIdOrderByCreatedAtAsc(userId);
+        return diaries.stream()
+                .map(diary -> new EmotionDiaryResponseDTO.EmotionDiaryDTO(
+                        diary.getId(),
+                        diary.getContent(),
+                        diary.getEmotion(),
+                        diary.getSummary(),
+                        diary.getFeedback(),
+                        diary.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 🚀 개요
감정 투자 일기 작성, 목록 조회 api를 구현했습니다.

## 📌 관련 이슈
- #67 

## ⏳ 작업 내용
- 모델, dto, service, controller, repository 구현
- 예외 처리 추가
- 응답 상태 코드 작성

## 📸 스크린샷
<img width="775" height="390" alt="스크린샷 2025-08-05 125833" src="https://github.com/user-attachments/assets/73f2f686-3b8e-4554-beb2-d76e4d0008d3" />
<img width="762" height="535" alt="image" src="https://github.com/user-attachments/assets/9ec2d802-6807-42b2-922f-ed67efc30d77" />

## 📝 참고 사항
- 아직 fastAPI 로직 구현 전이라 목데이터로 작성해뒀습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 감정 투자 일기 작성 및 조회 API가 추가되었습니다.
  * 감정 투자 일기 데이터를 위한 요청/응답 DTO와 JPA 엔티티가 도입되었습니다.
  * 감정 투자 일기 목록을 사용자별로 조회할 수 있습니다.

* **버그 수정**
  * 감정 투자 일기 작성 시, 내용이 비어있거나 감정 분석 서버 호출 실패에 대한 오류 메시지가 추가되었습니다.

* **기타**
  * 감정 리스트의 DB 저장 및 조회를 위한 변환기가 추가되었습니다.
  * 성공 및 오류 코드가 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->