### PR TITLE
[FEAT] 이미지 기반 종목 검색 api 구현 #69

### DIFF
--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
@@ -26,6 +26,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 종목 관련 예외 처리
     STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK404", "해당 종목을 찾을 수 없습니다."),
     STOCK_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK_DETAIL404", "해당 종목 상세 정보를 찾을 수 없습니다."),
+    IMAGE_STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK_IMAGE404", "이미지로 종목을 찾을 수 없습니다."),
 
     // 패턴 관련 예외 처리
     PATTERN_NOT_FOUND(HttpStatus.NOT_FOUND, "PATTERN404", "패턴이 존재하지 않습니다."),

--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
@@ -55,6 +55,11 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_CONTENT(HttpStatus.BAD_REQUEST, "DIARY400", "일기 내용이 비어있습니다."),
     FASTAPI_ANALYSIS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DIARY502", "FastAPI 감정 분석 서버 호출에 실패했습니다."),
 
+    // 이미지 관련 예외 처리
+    IMAGE_FILE_MISSING(HttpStatus.BAD_REQUEST, "IMAGE4001", "업로드된 이미지가 없습니다."),
+    IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "IMAGE4002", "업로드 가능한 최대 용량은 5MB입니다."),
+    INVALID_IMAGE_FILE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE4003", "지원하지 않는 이미지 형식입니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/synergyx/trading/controller/StockController.java
+++ b/src/main/java/com/synergyx/trading/controller/StockController.java
@@ -14,8 +14,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -83,5 +85,17 @@ public class StockController {
     public ResponseEntity<?> getAiTop20Stocks() {
         List<RankedStockDTO> list = stockRankingQueryService.getAiTop20();
         return ResponseEntity.ok(ApiResponse.onSuccess(list));
+    }
+
+    @Operation(summary = "이미지 기반 종목 검색", description = "상품 이미지를 기반으로 종목을 반환합니다.")
+    @PostMapping(value = "/search/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> searchStockByImage(
+            @Parameter(
+                    description = "업로드할 이미지 파일",
+                    required = true
+            )
+            @RequestParam("image") MultipartFile image) {
+        StockSearchResponseDTO result = stockSearchQueryService.searchStockByImage(image);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 }

--- a/src/main/java/com/synergyx/trading/dto/stockSearch/StockSearchFastApiWrapperDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/stockSearch/StockSearchFastApiWrapperDTO.java
@@ -1,0 +1,23 @@
+package com.synergyx.trading.dto.stockSearch;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// FastAPI에서 받은 응답을 감싸는 Wrapper DTO
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StockSearchFastApiWrapperDTO {
+
+    @JsonProperty("is_success")
+    private boolean isSuccess;
+
+    private String code;
+    private String message;
+
+    private StockSearchResponseDTO data;
+}

--- a/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryService.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryService.java
@@ -1,9 +1,12 @@
 package com.synergyx.trading.service.stockService.search;
 
 import com.synergyx.trading.dto.stockSearch.StockSearchResponseDTO;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface StockSearchQueryService {
     List<StockSearchResponseDTO> searchStocksByName(String keyword);
+    // 이미지 기반 검색
+    StockSearchResponseDTO searchStockByImage(MultipartFile image);
 }

--- a/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryServiceImpl.java
@@ -1,8 +1,8 @@
 package com.synergyx.trading.service.stockService.search;
 
-//import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
-//import com.synergyx.trading.apiPayload.exception.GeneralException;
 //import com.synergyx.trading.dto.stockSearch.StockSearchFastApiWrapperDTO;
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
 import com.synergyx.trading.dto.stockSearch.StockSearchResponseDTO;
 import com.synergyx.trading.repository.StockRepository;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +46,22 @@ public class StockSearchQueryServiceImpl implements StockSearchQueryService {
      */
     @Override
     public StockSearchResponseDTO searchStockByImage(MultipartFile image) {
+        // 파일 검증
+        if (image.isEmpty()) {
+            throw new GeneralException(ErrorStatus.IMAGE_FILE_MISSING);
+        }
+
+        // 파일 크기 검증 (5MB 제한)
+        if (image.getSize() > 5 * 1024 * 1024) {
+            throw new GeneralException(ErrorStatus.IMAGE_FILE_TOO_LARGE);
+        }
+
+        // 파일 타입 검증
+        String contentType = image.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new GeneralException(ErrorStatus.INVALID_IMAGE_FILE_TYPE);
+        }
+
         // TODO: FastAPI 연결 후 주석 삭제
 //        try {
 //            MultipartBodyBuilder builder = new MultipartBodyBuilder();

--- a/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryServiceImpl.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 //import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.reactive.function.client.WebClient;
+//import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
 

--- a/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryServiceImpl.java
@@ -1,9 +1,16 @@
 package com.synergyx.trading.service.stockService.search;
 
+//import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+//import com.synergyx.trading.apiPayload.exception.GeneralException;
+//import com.synergyx.trading.dto.stockSearch.StockSearchFastApiWrapperDTO;
 import com.synergyx.trading.dto.stockSearch.StockSearchResponseDTO;
 import com.synergyx.trading.repository.StockRepository;
 import lombok.RequiredArgsConstructor;
+//import org.springframework.http.MediaType;
+//import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
 
@@ -12,6 +19,7 @@ import java.util.List;
 public class StockSearchQueryServiceImpl implements StockSearchQueryService {
 
     private final StockRepository stockRepository;
+//    private final WebClient fastApiWebClient;
 
     /**
      * 종목명을 기준으로 종목 리스트를 검색합니다.
@@ -28,5 +36,45 @@ public class StockSearchQueryServiceImpl implements StockSearchQueryService {
                         .imageUrl(stock.getImageUrl())
                         .build())
                 .toList();
+    }
+
+    /**
+     * 이미지를 기반으로 종목을 추론하여 반환합니다.
+     *
+     * @param image 이미지 파일
+     * @return StockSearchResponseDTO
+     */
+    @Override
+    public StockSearchResponseDTO searchStockByImage(MultipartFile image) {
+        // TODO: FastAPI 연결 후 주석 삭제
+//        try {
+//            MultipartBodyBuilder builder = new MultipartBodyBuilder();
+//            builder.part("image", image.getResource());
+//
+//            StockSearchFastApiWrapperDTO response = fastApiWebClient.post()
+//                    .uri("/image-search")
+//                    .contentType(MediaType.MULTIPART_FORM_DATA)
+//                    .bodyValue(builder.build())
+//                    .retrieve()
+//                    .bodyToMono(StockSearchFastApiWrapperDTO.class)
+//                    .block();
+//
+//            if (response == null || !response.isSuccess()) {
+//                throw new GeneralException(ErrorStatus.IMAGE_STOCK_NOT_FOUND);
+//            }
+//
+//            return response.getData();
+//
+//        } catch (Exception e) {
+//            throw new GeneralException(ErrorStatus.IMAGE_STOCK_NOT_FOUND);
+//        }
+//    }
+        // TODO: FastAPI 연결 후 삭제
+        // 목데이터
+        return StockSearchResponseDTO.builder()
+                .id(1L)
+                .name("삼성전자")
+                .imageUrl("https://picsum.photos/30/30")
+                .build();
     }
 }


### PR DESCRIPTION
## 🚀 개요
이미지 기반 종목 검색 api를 구현했습니다.

## 📌 관련 이슈
- #69 

## ⏳ 작업 내용
- dto, service, controller, repository 구현
- 예외 처리 추가
- 응답 상태 코드 작성

## 📸 스크린샷
<img width="432" height="242" alt="image" src="https://github.com/user-attachments/assets/d44ab118-3233-4f30-8dcb-f05a5be20689" />

## 📝 참고 사항
- 아직 fastAPI 로직 구현 전이라 목데이터로 작성해뒀습니다.
- 프론트엔드에서 해당 응답 결과를 통해 종목 상세 페이지 반환 해야함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이미지 업로드를 통한 종목 검색 API가 추가되었습니다. 이제 이미지를 이용해 종목을 검색할 수 있습니다.
* **버그 수정**
  * 이미지 기반 종목 검색 실패 시 새로운 에러 메시지가 제공됩니다.
  * 업로드된 이미지가 없거나, 크기 초과, 지원하지 않는 형식일 때 상세한 오류 안내가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->