### PR TITLE
[FEAT] 예측값 계산 기능 구현 #71

### DIFF
--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
@@ -27,6 +27,8 @@ public enum ErrorStatus implements BaseErrorCode {
     STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK404", "해당 종목을 찾을 수 없습니다."),
     STOCK_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK_DETAIL404", "해당 종목 상세 정보를 찾을 수 없습니다."),
     IMAGE_STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK_IMAGE404", "이미지로 종목을 찾을 수 없습니다."),
+    STOCK_PREDICTION_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK4041", "종목의 예측 데이터를 찾을 수 없습니다."),
+    STOCK_CLOSE_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK4042", "해당 종목의 종가를 찾을 수 없습니다."),
 
     // 패턴 관련 예외 처리
     PATTERN_NOT_FOUND(HttpStatus.NOT_FOUND, "PATTERN404", "패턴이 존재하지 않습니다."),

--- a/src/main/java/com/synergyx/trading/dto/stockDetail/PredictionWindowSummaryDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/stockDetail/PredictionWindowSummaryDTO.java
@@ -13,10 +13,9 @@ public class PredictionWindowSummaryDTO {
     private Long stockId;
     private LocalDate asOfDate;
     private int windowDays;
-    private double upperForecast;
-    private double lowerForecast;
-    private double fairSell;
-    private double fairBuy;
+    private long upperForecast;
+    private long lowerForecast;
+    private long fairSell;
+    private long fairBuy;
     private double bufferPct;
-    private LocalDateTime expiresAt;
 }

--- a/src/main/java/com/synergyx/trading/dto/stockDetail/PredictionWindowSummaryDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/stockDetail/PredictionWindowSummaryDTO.java
@@ -1,0 +1,22 @@
+package com.synergyx.trading.dto.stockDetail;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+// 내부 계산용
+public class PredictionWindowSummaryDTO {
+    private Long stockId;
+    private LocalDate asOfDate;
+    private int windowDays;
+    private double upperForecast;
+    private double lowerForecast;
+    private double fairSell;
+    private double fairBuy;
+    private double bufferPct;
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/com/synergyx/trading/dto/stockDetail/StockDetailResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/stockDetail/StockDetailResponseDTO.java
@@ -13,7 +13,6 @@ public class StockDetailResponseDTO {
     private String changeRate; // 1.12%
     private String changeAmount; // 600
     private Boolean isWatchlist;
-    private Boolean isTradeNotificationEnabled;
     private PredictionDTO prediction;
     private FinancialsDTO financials;
 

--- a/src/main/java/com/synergyx/trading/model/Prediction.java
+++ b/src/main/java/com/synergyx/trading/model/Prediction.java
@@ -1,0 +1,56 @@
+package com.synergyx.trading.model;
+
+import com.synergyx.trading.model.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+@Entity
+@Table(
+        name = "prediction",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_stock_target_date",
+                        columnNames = {"stock_id", "target_date"}
+                )
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Prediction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "stock_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_prediction_stock")
+    )
+    private Stock stock;
+
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate;
+
+    @Column(name = "predicted_close", nullable = false)
+    private Double predictedClose;
+
+    @Column(name = "predicted_high", nullable = false)
+    private Double predictedHigh;
+
+    @Column(name = "predicted_low", nullable = false)
+    private Double predictedLow;
+
+    @Column(name = "recommended_sell")
+    private Double recommendedSell;
+
+    @Column(name = "recommended_buy")
+    private Double recommendedBuy;
+}

--- a/src/main/java/com/synergyx/trading/repository/PredictionRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/PredictionRepository.java
@@ -17,6 +17,7 @@ public interface PredictionRepository extends JpaRepository<Prediction, Long> {
                 FROM Prediction p
                 WHERE p.stock.id = :stockId
                   AND p.targetDate BETWEEN :startDate AND :endDate
+                GROUP BY p.stock.id
             """)
     Optional<PredictionWindowAggProjection> aggregateWindow(
             @Param("stockId") Long stockId,

--- a/src/main/java/com/synergyx/trading/repository/PredictionRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/PredictionRepository.java
@@ -1,0 +1,26 @@
+package com.synergyx.trading.repository;
+
+import com.synergyx.trading.model.Prediction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface PredictionRepository extends JpaRepository<Prediction, Long> {
+    @Query("""
+                SELECT MAX(p.predictedClose) AS upperForecast,
+                       MIN(p.predictedClose) AS lowerForecast
+                FROM Prediction p
+                WHERE p.stock.id = :stockId
+                  AND p.targetDate BETWEEN :startDate AND :endDate
+            """)
+    Optional<PredictionWindowAggProjection> aggregateWindow(
+            @Param("stockId") Long stockId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+}

--- a/src/main/java/com/synergyx/trading/repository/PredictionWindowAggProjection.java
+++ b/src/main/java/com/synergyx/trading/repository/PredictionWindowAggProjection.java
@@ -1,0 +1,8 @@
+package com.synergyx.trading.repository;
+
+public interface PredictionWindowAggProjection {
+
+    Double getUpperForecast();
+
+    Double getLowerForecast();
+}

--- a/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryService.java
+++ b/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryService.java
@@ -1,7 +1,9 @@
 package com.synergyx.trading.service.predictionService;
 
-import com.synergyx.trading.dto.stockDetail.StockDetailResponseDTO;
+import com.synergyx.trading.dto.stockDetail.PredictionWindowSummaryDTO;
+
+import java.time.LocalDate;
 
 public interface PredictionQueryService {
-    StockDetailResponseDTO.PredictionDTO getPredictionByStockId(Long stockId);
+    PredictionWindowSummaryDTO getWindowSummary(Long stockId, LocalDate asOfDate);
 }

--- a/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryServiceImpl.java
@@ -36,7 +36,7 @@ public class PredictionQueryServiceImpl implements PredictionQueryService {
 
         // 예측 윈도우 계산
         LocalDate startDate = getNextBizDay(asOfDate);
-        LocalDate endDate = addBizDays(startDate, 13); // 시작일 포함 총 14영업일
+        LocalDate endDate = addBizDays(startDate, WINDOW_DAYS - 1); // 시작일 포함 총 14영업일
 
         log.debug("[PredictionQueryService] Prediction window startDate={}, endDate={}", startDate, endDate);
 
@@ -48,14 +48,39 @@ public class PredictionQueryServiceImpl implements PredictionQueryService {
                     return new GeneralException(ErrorStatus.STOCK_PREDICTION_NOT_FOUND);
                 });
 
-        double upper = agg.getUpperForecast();
-        double lower = agg.getLowerForecast();
+        long upper = Math.round(agg.getUpperForecast());
+        long lower = Math.round(agg.getLowerForecast());
 
         log.debug("[PredictionQueryService] Upper forecast={}, Lower forecast={}", upper, lower);
 
+        // 예측값 유효성 검사
+        if (!Double.isFinite(upper) || !Double.isFinite(lower)) {
+            log.warn("[PredictionQueryService] Invalid forecasts: upper={}, lower={}", upper, lower);
+            throw new GeneralException(ErrorStatus.STOCK_PREDICTION_NOT_FOUND);
+        }
+
+        // 상/하한 역전 방어
+        if (upper < lower) {
+            log.warn("[PredictionQueryService] upper < lower (upper={}, lower={}) - swapping", upper, lower);
+            long t = upper;
+            upper = lower;
+            lower = t;
+        }
+
         // 버퍼 적용 + 틱 단위 조정
-        double fairSell = roundDown(upper * (1 - BUFFER_PCT), tickFor(upper));
-        double fairBuy = roundUp(lower * (1 + BUFFER_PCT), tickFor(lower));
+        long bufferedUpper = Math.round(upper * (1 - BUFFER_PCT));
+        long bufferedLower = Math.round(lower * (1 + BUFFER_PCT));
+        long fairSell = roundDown(bufferedUpper, tickFor(bufferedUpper));
+        long fairBuy = roundUp(bufferedLower, tickFor(bufferedLower));
+
+        // 매도/매수 역전 방어
+        if (fairBuy > fairSell) {
+            log.warn("[PredictionQueryService] fairBuy({}) > fairSell({}) - adjusting to midpoint", fairBuy, fairSell);
+            long mid = Math.round((upper + lower) / 2.0);
+            long tick = tickFor(mid);
+            fairBuy = roundDown(mid, tick);
+            fairSell = roundUp(mid, tick);
+        }
 
         log.debug("[PredictionQueryService] Fair sell(after buffer/tick)={}, Fair buy(after buffer/tick)={}",
                 fairSell, fairBuy);
@@ -69,7 +94,6 @@ public class PredictionQueryServiceImpl implements PredictionQueryService {
                 .fairSell(fairSell)
                 .fairBuy(fairBuy)
                 .bufferPct(BUFFER_PCT)
-                .expiresAt(asOfDate.plusDays(1).atTime(9, 0))
                 .build();
 
         log.debug("[PredictionQueryService] Returning DTO={}", dto);
@@ -77,6 +101,9 @@ public class PredictionQueryServiceImpl implements PredictionQueryService {
         return dto;
     }
 
+    /**
+     * 다음 영업일 계산
+     */
     private LocalDate getNextBizDay(LocalDate date) {
         LocalDate next = date.plusDays(1);
         while (isWeekend(next)) {
@@ -85,6 +112,9 @@ public class PredictionQueryServiceImpl implements PredictionQueryService {
         return next;
     }
 
+    /**
+     * 영업일 기준 days일 뒤 날짜 계산
+     */
     private LocalDate addBizDays(LocalDate start, int days) {
         LocalDate date = start;
         int added = 0;
@@ -103,24 +133,30 @@ public class PredictionQueryServiceImpl implements PredictionQueryService {
     }
 
     /**
-     * 가격대에 맞는 호가 단위를 반환합니다.
+     * 가격대에 맞는 호가 단위를 반환합니다. (코스피 기준)
      * 구간별 최소 호가 단위 기준입니다.
      * <p>
-     * - 4,800원 → 1원 단위
-     * - 9,500원 → 5원 단위
-     * - 42,000원 → 10원 단위
-     * - 87,000원 → 50원 단위
-     * - 120,000원 → 100원 단위
+     * ex:
+     * - 1,500원  → 1원 단위
+     * - 3,000원  → 5원 단위
+     * - 8,000원  → 10원 단위
+     * - 15,000원 → 10원 단위
+     * - 42,000원 → 50원 단위
+     * - 87,000원 → 100원 단위
+     * - 350,000원 → 500원 단위
+     * - 600,000원 → 1,000원 단위
      *
      * @param price 적용할 가격
      * @return 호가 단위
      */
-    private double tickFor(double price) {
-        if (price < 5000) return 1;
-        if (price < 10000) return 5;
-        if (price < 50000) return 10;
-        if (price < 100000) return 50;
-        return 100;
+    private long tickFor(double price) {
+        if (price < 2000) return 1;
+        else if (price < 5000) return 5;
+        else if (price < 20000) return 10;
+        else if (price < 50000) return 50;
+        else if (price < 200000) return 100;
+        else if (price < 500000) return 500;
+        return 1000;
     }
 
     /**
@@ -130,14 +166,14 @@ public class PredictionQueryServiceImpl implements PredictionQueryService {
      * <p>
      * ex:
      * - value=62,622, tick=50 → 62,600
-     * - value=9,987, tick=5 → 9,985
+     * - value=9,987, tick=10 → 9,980
      *
      * @param value
      * @param tick
      * @return
      */
-    private double roundDown(double value, double tick) {
-        return Math.floor(value / tick) * tick;
+    private long roundDown(long value, long tick) {
+        return (value / tick) * tick;
     }
 
     /**
@@ -147,13 +183,13 @@ public class PredictionQueryServiceImpl implements PredictionQueryService {
      * <p>
      * ex:
      * - value=53,418, tick=100 → 53,500
-     * - value=9,987, tick=5 → 9,990
+     * - value=9,987, tick=10 → 9,990
      *
      * @param value
      * @param tick
      * @return
      */
-    private double roundUp(double value, double tick) {
-        return Math.ceil(value / tick) * tick;
+    private long roundUp(long value, long tick) {
+        return ((value + tick - 1) / tick) * tick;
     }
 }

--- a/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryServiceImpl.java
@@ -48,24 +48,27 @@ public class PredictionQueryServiceImpl implements PredictionQueryService {
                     return new GeneralException(ErrorStatus.STOCK_PREDICTION_NOT_FOUND);
                 });
 
-        long upper = Math.round(agg.getUpperForecast());
-        long lower = Math.round(agg.getLowerForecast());
-
-        log.debug("[PredictionQueryService] Upper forecast={}, Lower forecast={}", upper, lower);
+        double rawUpper = agg.getUpperForecast();
+        double rawLower = agg.getLowerForecast();
 
         // 예측값 유효성 검사
-        if (!Double.isFinite(upper) || !Double.isFinite(lower)) {
-            log.warn("[PredictionQueryService] Invalid forecasts: upper={}, lower={}", upper, lower);
+        if (!Double.isFinite(rawUpper) || !Double.isFinite(rawLower)) {
+            log.warn("[PredictionQueryService] Invalid forecasts: upper={}, lower={}", rawUpper, rawLower);
             throw new GeneralException(ErrorStatus.STOCK_PREDICTION_NOT_FOUND);
         }
 
         // 상/하한 역전 방어
-        if (upper < lower) {
-            log.warn("[PredictionQueryService] upper < lower (upper={}, lower={}) - swapping", upper, lower);
-            long t = upper;
-            upper = lower;
-            lower = t;
+        if (rawUpper < rawLower) {
+            log.warn("[PredictionQueryService] upper < lower (upper={}, lower={}) - swapping", rawUpper, rawLower);
+            double tmp = rawUpper;
+            rawUpper = rawLower;
+            rawLower = tmp;
         }
+
+        // 반올림 적용
+        long upper = Math.round(rawUpper);
+        long lower = Math.round(rawLower);
+        log.debug("[PredictionQueryService] Upper forecast={}, Lower forecast={}", upper, lower);
 
         // 버퍼 적용 + 틱 단위 조정
         long bufferedUpper = Math.round(upper * (1 - BUFFER_PCT));

--- a/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/predictionService/PredictionQueryServiceImpl.java
@@ -1,21 +1,159 @@
 package com.synergyx.trading.service.predictionService;
 
-import com.synergyx.trading.dto.stockDetail.StockDetailResponseDTO;
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.dto.stockDetail.PredictionWindowSummaryDTO;
+import com.synergyx.trading.repository.PredictionRepository;
+import com.synergyx.trading.repository.PredictionWindowAggProjection;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import static com.synergyx.trading.util.ParsingUtil.toFormattedNumber;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class PredictionQueryServiceImpl implements PredictionQueryService {
+
+    private final PredictionRepository predictionRepository;
+
+    private static final int WINDOW_DAYS = 14; // 예측 윈도우
+    private static final double BUFFER_PCT = 0.006; // 버퍼
+
+    /**
+     * 특정 종목의 예측 상/하한가 적정 매수/매도 가를 계산합니다.
+     *
+     * @param stockId
+     * @param asOfDate 오늘 날짜
+     * @return PredictionWindowSummaryDTO 계산 전용 dto
+     */
     @Override
-    public StockDetailResponseDTO.PredictionDTO getPredictionByStockId(Long stockId) {
-        // TODO: 추후 predict 테이블에서 조회로 변경
-        return StockDetailResponseDTO.PredictionDTO.builder()
-                .upperBound(toFormattedNumber(63000.0))
-                .lowerBound(toFormattedNumber(53100.0))
-                .buyPrice(toFormattedNumber(52900.0))
-                .sellPrice(toFormattedNumber(62500.0))
-                .targetRange("20일 이내")
+    @Transactional(readOnly = true)
+    public PredictionWindowSummaryDTO getWindowSummary(Long stockId, LocalDate asOfDate) {
+
+        // 예측 윈도우 계산
+        LocalDate startDate = getNextBizDay(asOfDate);
+        LocalDate endDate = addBizDays(startDate, 13); // 시작일 포함 총 14영업일
+
+        log.debug("[PredictionQueryService] Prediction window startDate={}, endDate={}", startDate, endDate);
+
+        // 예측가 집계 조회
+        PredictionWindowAggProjection agg = predictionRepository.aggregateWindow(stockId, startDate, endDate)
+                .orElseThrow(() -> {
+                    log.warn("[PredictionQueryService] No prediction data found for stockId={}, start={}, end={}",
+                            stockId, startDate, endDate);
+                    return new GeneralException(ErrorStatus.STOCK_PREDICTION_NOT_FOUND);
+                });
+
+        double upper = agg.getUpperForecast();
+        double lower = agg.getLowerForecast();
+
+        log.debug("[PredictionQueryService] Upper forecast={}, Lower forecast={}", upper, lower);
+
+        // 버퍼 적용 + 틱 단위 조정
+        double fairSell = roundDown(upper * (1 - BUFFER_PCT), tickFor(upper));
+        double fairBuy = roundUp(lower * (1 + BUFFER_PCT), tickFor(lower));
+
+        log.debug("[PredictionQueryService] Fair sell(after buffer/tick)={}, Fair buy(after buffer/tick)={}",
+                fairSell, fairBuy);
+
+        PredictionWindowSummaryDTO dto = PredictionWindowSummaryDTO.builder()
+                .stockId(stockId)
+                .asOfDate(asOfDate)
+                .windowDays(WINDOW_DAYS)
+                .upperForecast(upper)
+                .lowerForecast(lower)
+                .fairSell(fairSell)
+                .fairBuy(fairBuy)
+                .bufferPct(BUFFER_PCT)
+                .expiresAt(asOfDate.plusDays(1).atTime(9, 0))
                 .build();
+
+        log.debug("[PredictionQueryService] Returning DTO={}", dto);
+
+        return dto;
+    }
+
+    private LocalDate getNextBizDay(LocalDate date) {
+        LocalDate next = date.plusDays(1);
+        while (isWeekend(next)) {
+            next = next.plusDays(1);
+        }
+        return next;
+    }
+
+    private LocalDate addBizDays(LocalDate start, int days) {
+        LocalDate date = start;
+        int added = 0;
+        while (added < days) {
+            date = date.plusDays(1);
+            if (!isWeekend(date)) {
+                added++;
+            }
+        }
+        return date;
+    }
+
+    private boolean isWeekend(LocalDate date) {
+        return date.getDayOfWeek() == DayOfWeek.SATURDAY ||
+                date.getDayOfWeek() == DayOfWeek.SUNDAY;
+    }
+
+    /**
+     * 가격대에 맞는 호가 단위를 반환합니다.
+     * 구간별 최소 호가 단위 기준입니다.
+     * <p>
+     * - 4,800원 → 1원 단위
+     * - 9,500원 → 5원 단위
+     * - 42,000원 → 10원 단위
+     * - 87,000원 → 50원 단위
+     * - 120,000원 → 100원 단위
+     *
+     * @param price 적용할 가격
+     * @return 호가 단위
+     */
+    private double tickFor(double price) {
+        if (price < 5000) return 1;
+        if (price < 10000) return 5;
+        if (price < 50000) return 10;
+        if (price < 100000) return 50;
+        return 100;
+    }
+
+    /**
+     * 가격을 호가 단위에 맞춰 내림합니다.
+     * - 매도가 계산 시 사용
+     * - 해당 호가 단위의 가장 가까운 값으로 조정
+     * <p>
+     * ex:
+     * - value=62,622, tick=50 → 62,600
+     * - value=9,987, tick=5 → 9,985
+     *
+     * @param value
+     * @param tick
+     * @return
+     */
+    private double roundDown(double value, double tick) {
+        return Math.floor(value / tick) * tick;
+    }
+
+    /**
+     * 가격을 호가 단위에 맞춰 올림합니다.
+     * - 매수가 계산 시 사용
+     * - 해당 호가 단위의 가장 가까운 높은 값으로 조정
+     * <p>
+     * ex:
+     * - value=53,418, tick=100 → 53,500
+     * - value=9,987, tick=5 → 9,990
+     *
+     * @param value
+     * @param tick
+     * @return
+     */
+    private double roundUp(double value, double tick) {
+        return Math.ceil(value / tick) * tick;
     }
 }

--- a/src/main/java/com/synergyx/trading/service/stockService/detail/StockDetailQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/detail/StockDetailQueryServiceImpl.java
@@ -67,7 +67,6 @@ public class StockDetailQueryServiceImpl implements StockDetailQueryService {
                 .changeRate(stockDetail.getChangeRate() + "%")
                 .changeAmount(toFormattedNumber(stockDetail.getChangeAmount()))
                 .isWatchlist(isWatchlist)
-                .isTradeNotificationEnabled(false) // todo: delete
                 .prediction(predictUi)
                 .financials(financials)
                 .build();

--- a/src/main/java/com/synergyx/trading/service/stockService/detail/StockDetailQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/detail/StockDetailQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.synergyx.trading.service.stockService.detail;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.synergyx.trading.dto.stockDetail.PredictionWindowSummaryDTO;
 import com.synergyx.trading.dto.stockDetail.StockDetailResponseDTO;
 import com.synergyx.trading.model.Stock;
 import com.synergyx.trading.model.StockDetail;
@@ -15,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 import static com.synergyx.trading.util.ParsingUtil.*;
 
@@ -51,10 +54,10 @@ public class StockDetailQueryServiceImpl implements StockDetailQueryService {
 
         boolean isWatchlist = interestStockRepository.existsByUserIdAndStockId(userId, stockId);
 
-        // todo: 아직 미구현 → false 고정
-        boolean isTradeNotificationEnabled = false;
-
-        StockDetailResponseDTO.PredictionDTO prediction = predictionQueryService.getPredictionByStockId(stock.getId());
+        // 예측 데이터
+        LocalDate asOfDate = LocalDate.now(); // 오늘의 날짜
+        PredictionWindowSummaryDTO prediction = predictionQueryService.getWindowSummary(stockId, asOfDate);
+        StockDetailResponseDTO.PredictionDTO predictUi = toUiPrediction(prediction);
 
         StockDetailResponseDTO.FinancialsDTO financials = parseFinancialData(stockDetail);
 
@@ -64,8 +67,8 @@ public class StockDetailQueryServiceImpl implements StockDetailQueryService {
                 .changeRate(stockDetail.getChangeRate() + "%")
                 .changeAmount(toFormattedNumber(stockDetail.getChangeAmount()))
                 .isWatchlist(isWatchlist)
-                .isTradeNotificationEnabled(isTradeNotificationEnabled)
-                .prediction(prediction)
+                .isTradeNotificationEnabled(false) // todo: delete
+                .prediction(predictUi)
                 .financials(financials)
                 .build();
     }
@@ -99,6 +102,22 @@ public class StockDetailQueryServiceImpl implements StockDetailQueryService {
             log.error("[DETAIL] 재무데이터 파싱 실패 - symbol Id: {}", stockDetail.getId(), e);
             throw new RuntimeException("재무데이터 파싱 실패", e);
         }
+    }
+
+    /**
+     * 예측 dto -> 예측 ui dto로 변환합니다.
+     *
+     * @param s
+     * @return
+     */
+    private StockDetailResponseDTO.PredictionDTO toUiPrediction(PredictionWindowSummaryDTO s) {
+        return StockDetailResponseDTO.PredictionDTO.builder()
+                .upperBound(toFormattedNumber(s.getUpperForecast()))
+                .lowerBound(toFormattedNumber(s.getLowerForecast()))
+                .buyPrice(toFormattedNumber(s.getFairBuy()))
+                .sellPrice(toFormattedNumber(s.getFairSell()))
+                .targetRange(s.getWindowDays() + "일 이내")
+                .build();
     }
 }
 


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
예측값 조회 기능을 구현했습니다.

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #71

## ⏳ 작업 내용
- 예측값을 이용하여 상/하한가 적정 매도/매수 가격 계산 로직 추가
- 매매 알림 여부가 사용되지 않아서 삭제함

## 📸 스크린샷
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 계산 가격 db저장이 필요한 경우 fastapi의 배치 로직에 계산 로직을 포함할 예정입니다.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 종목 상세에 14영업일 예측 창 요약 제공: 상단/하단 예측가, 공정 매수·매도가, 버퍼율과 만료 범위("N일 이내") 표기.
  - 예측 데이터 또는 종가 부재 시 사용자 친화적 NOT_FOUND 오류 메시지 추가로 가시성 향상.
- Refactor
  - 종목 상세 응답을 예측 창 기반으로 재구성하고 UI용 변환 로직 도입.
  - 가격 단위 반영한 반올림/버킷팅 적용으로 공정가 표시 정확도 개선; 거래 알림 사용 여부 필드 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->