### PR TITLE
[FEAT] fastAPI 연결 #69

### DIFF
--- a/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryServiceImpl.java
@@ -1,16 +1,17 @@
 package com.synergyx.trading.service.stockService.search;
 
-//import com.synergyx.trading.dto.stockSearch.StockSearchFastApiWrapperDTO;
+import com.synergyx.trading.dto.stockSearch.StockSearchFastApiWrapperDTO;
 import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
 import com.synergyx.trading.apiPayload.exception.GeneralException;
 import com.synergyx.trading.dto.stockSearch.StockSearchResponseDTO;
+import com.synergyx.trading.model.Stock;
 import com.synergyx.trading.repository.StockRepository;
 import lombok.RequiredArgsConstructor;
-//import org.springframework.http.MediaType;
-//import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-//import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
 
@@ -19,7 +20,7 @@ import java.util.List;
 public class StockSearchQueryServiceImpl implements StockSearchQueryService {
 
     private final StockRepository stockRepository;
-//    private final WebClient fastApiWebClient;
+    private final WebClient fastApiWebClient;
 
     /**
      * 종목명을 기준으로 종목 리스트를 검색합니다.
@@ -62,35 +63,34 @@ public class StockSearchQueryServiceImpl implements StockSearchQueryService {
             throw new GeneralException(ErrorStatus.INVALID_IMAGE_FILE_TYPE);
         }
 
-        // TODO: FastAPI 연결 후 주석 삭제
-//        try {
-//            MultipartBodyBuilder builder = new MultipartBodyBuilder();
-//            builder.part("image", image.getResource());
-//
-//            StockSearchFastApiWrapperDTO response = fastApiWebClient.post()
-//                    .uri("/image-search")
-//                    .contentType(MediaType.MULTIPART_FORM_DATA)
-//                    .bodyValue(builder.build())
-//                    .retrieve()
-//                    .bodyToMono(StockSearchFastApiWrapperDTO.class)
-//                    .block();
-//
-//            if (response == null || !response.isSuccess()) {
-//                throw new GeneralException(ErrorStatus.IMAGE_STOCK_NOT_FOUND);
-//            }
-//
-//            return response.getData();
-//
-//        } catch (Exception e) {
-//            throw new GeneralException(ErrorStatus.IMAGE_STOCK_NOT_FOUND);
-//        }
-//    }
-        // TODO: FastAPI 연결 후 삭제
-        // 목데이터
-        return StockSearchResponseDTO.builder()
-                .id(1L)
-                .name("삼성전자")
-                .imageUrl("https://picsum.photos/30/30")
-                .build();
+        try {
+            MultipartBodyBuilder builder = new MultipartBodyBuilder();
+            builder.part("image", image.getResource());
+
+            StockSearchFastApiWrapperDTO response = fastApiWebClient.post()
+                    .uri("/api/v1/stocks/search-by-image")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .bodyValue(builder.build())
+                    .retrieve()
+                    .bodyToMono(StockSearchFastApiWrapperDTO.class)
+                    .block();
+
+            if (response == null || !response.isSuccess()) {
+                throw new GeneralException(ErrorStatus.IMAGE_STOCK_NOT_FOUND);
+            }
+
+            Long stockId = response.getData().getId();
+            Stock stock = stockRepository.findById(stockId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.STOCK_NOT_FOUND));
+
+            return StockSearchResponseDTO.builder()
+                    .id(stock.getId())
+                    .name(stock.getName())
+                    .imageUrl(stock.getImageUrl())
+                    .build();
+
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.IMAGE_STOCK_NOT_FOUND);
+        }
     }
 }


### PR DESCRIPTION
## 🚀 개요
fastAPI와 연결하여 기능 구현을 완료했습니다.

## 📌 관련 이슈
- Closes #69 

## ⏳ 작업 내용
- 쿼리 서비스 구현

## 📸 스크린샷
<img width="942" height="252" alt="image" src="https://github.com/user-attachments/assets/7f291d7f-881d-4caa-a6df-bf712c7df04a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 이미지 기반 종목 검색이 실제 서비스와 연동되어 실제 결과를 제공합니다. 업로드한 이미지로 종목을 식별하고 상세 정보를 반환합니다.

- 버그 수정
  - 더 이상 임시/예시 데이터가 반환되지 않으며, 검색 결과 신뢰성이 향상되었습니다.
  - 이미지에서 종목을 찾지 못한 경우 명확한 오류 응답을 제공하여 사용자 피드백을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->