### PR TITLE
[FIX] 이미지 업로드 크기 제한 상향 (5MB → 20MB) #69

### DIFF
--- a/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/search/StockSearchQueryServiceImpl.java
@@ -52,8 +52,8 @@ public class StockSearchQueryServiceImpl implements StockSearchQueryService {
             throw new GeneralException(ErrorStatus.IMAGE_FILE_MISSING);
         }
 
-        // 파일 크기 검증 (5MB 제한)
-        if (image.getSize() > 5 * 1024 * 1024) {
+        // 파일 크기 검증 (20MB 제한)
+        if (image.getSize() > 20 * 1024 * 1024) {
             throw new GeneralException(ErrorStatus.IMAGE_FILE_TOO_LARGE);
         }
 


### PR DESCRIPTION
## 🚀 개요
이미지 업로드 크기 제한 상향

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #69 

## ⏳ 작업 내용
- 이미지 업로드 크기를 최대 20MB까지 가능하도록 했습니다.
- response 413 오류를 발견하여 yml에 파일 최대 크기를 명시해놨습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 이미지 기반 종목 검색에서 업로드 가능한 이미지 최대 용량을 5MB에서 20MB로 확대했습니다. 더 큰 이미지 업로드가 가능해졌으며 용량 초과로 인한 업로드 실패가 감소합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->