### PR TITLE
[FEAT] 감정 일기 fastAPI 연동 구현 #67

### DIFF
--- a/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryCommandServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryCommandServiceImpl.java
@@ -6,12 +6,10 @@ import com.synergyx.trading.dto.emotionDiary.EmotionDiaryRequestDTO;
 import com.synergyx.trading.dto.emotionDiary.EmotionDiaryResponseDTO;
 import com.synergyx.trading.model.*;
 import com.synergyx.trading.repository.*;
-//import com.synergyx.trading.service.emotionDiaryService.client.EmotionDiaryClientService;
+import com.synergyx.trading.service.emotionDiaryService.client.EmotionDiaryClientService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,7 +17,7 @@ public class EmotionDiaryCommandServiceImpl implements  EmotionDiaryCommandServi
 
     private final EmotionDiaryRepository emotionDiaryRepository;
     private final UserRepository userRepository;
-//    private final EmotionDiaryClientService emotionDiaryClientService;
+    private final EmotionDiaryClientService emotionDiaryClientService;
 
     // 감정 투자 일기 생성
     @Override
@@ -35,28 +33,15 @@ public class EmotionDiaryCommandServiceImpl implements  EmotionDiaryCommandServi
             throw new GeneralException(ErrorStatus.INVALID_CONTENT);
         }
 
-        // TODO: fastAPI 연결 후 주석 삭제
-//        EmotionDiaryResponseDTO.EmotionAnalysisResultDTO result = emotionDiaryClientService.callEmotionDiaryAPI(dto.getContent());
-//
-//        EmotionDiary diary = emotionDiaryRepository.save(
-//                EmotionDiary.builder()
-//                        .user(user)
-//                        .content(dto.getContent())
-//                        .emotion(result.getEmotion())
-//                        .summary(result.getSummary())
-//                        .feedback(result.getFeedback())
-//                        .build()
-//        );
+        EmotionDiaryResponseDTO.EmotionAnalysisResultDTO result = emotionDiaryClientService.callEmotionDiaryAPI(dto.getContent());
 
-        // TODO: fastAPI 연결 후 삭제
-        // 목데이터
         EmotionDiary diary = emotionDiaryRepository.save(
                 EmotionDiary.builder()
                         .user(user)
                         .content(dto.getContent())
-                        .emotion(List.of("기쁨", "만족", "뿌듯함"))
-                        .summary("주가 급등으로 인한 큰 수익과 긍정적인 감정 표현")
-                        .feedback("수익 실현 축하드려요! 앞으로도 꾸준한 리스크 관리와 분산 투자를 유지해보세요.")
+                        .emotion(result.getEmotion())
+                        .summary(result.getSummary())
+                        .feedback(result.getFeedback())
                         .build()
         );
 

--- a/src/main/java/com/synergyx/trading/service/emotionDiaryService/client/EmotionDiaryClientService.java
+++ b/src/main/java/com/synergyx/trading/service/emotionDiaryService/client/EmotionDiaryClientService.java
@@ -1,0 +1,41 @@
+package com.synergyx.trading.service.emotionDiaryService.client;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.dto.emotionDiary.EmotionDiaryRequestDTO;
+import com.synergyx.trading.dto.emotionDiary.EmotionDiaryResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionDiaryClientService {
+
+    private final WebClient fastApiWebClient;
+
+    public EmotionDiaryResponseDTO.EmotionAnalysisResultDTO callEmotionDiaryAPI(String content) {
+
+        EmotionDiaryRequestDTO request = EmotionDiaryRequestDTO.builder()
+                .content(content)
+                .build();
+
+        try {
+            EmotionDiaryResponseDTO.EmotionDiaryWrapperResponseDTO response = fastApiWebClient.post()
+                    .uri("/api/v1/diaries")
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(EmotionDiaryResponseDTO.EmotionDiaryWrapperResponseDTO.class)
+                    .block();
+
+            if (response == null || !response.isSuccess()) {
+                throw new GeneralException(ErrorStatus.FASTAPI_ANALYSIS_FAILED);
+            }
+
+            return response.getData();
+
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.FASTAPI_ANALYSIS_FAILED);
+        }
+    }
+}


### PR DESCRIPTION
## 🚀 개요
감정 일기 기능을 fastAPI와 연결했습니다.

## 📌 관련 이슈
- Closes #67 

## ⏳ 작업 내용
- 서비스/서비스 lmpl 로직 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 감정 일기 작성 시 AI 분석을 통해 감정, 요약, 피드백이 자동 생성됩니다.
  - 고정된 모의 값 대신 실제 분석 결과가 저장·표시됩니다.
  - 분석 과정의 예외 처리 강화로 실패 시 명확한 안내와 안정적인 동작을 제공합니다.
  - 저장 절차의 신뢰성이 향상되어 데이터 일관성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->