### PR TITLE
[FEAT] 감정 투자 일기 삭제 기능 구현 #67

### DIFF
--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
@@ -56,12 +56,12 @@ public enum ErrorStatus implements BaseErrorCode {
     // 감정 투자 일기 관련 예외 처리
     INVALID_CONTENT(HttpStatus.BAD_REQUEST, "DIARY400", "일기 내용이 비어있습니다."),
     FASTAPI_ANALYSIS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DIARY502", "FastAPI 감정 분석 서버 호출에 실패했습니다."),
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY404", "해당 일기를 찾을 수 없습니다."),
 
     // 이미지 관련 예외 처리
     IMAGE_FILE_MISSING(HttpStatus.BAD_REQUEST, "IMAGE4001", "업로드된 이미지가 없습니다."),
     IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "IMAGE4002", "업로드 가능한 최대 용량은 5MB입니다."),
     INVALID_IMAGE_FILE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE4003", "지원하지 않는 이미지 형식입니다."),
-
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
@@ -47,7 +47,7 @@ public enum SuccessStatus implements BaseCode {
 
     // 감정 투자 일기
     SUCCESS_WRITE_EMOTION_DIARY(HttpStatus.OK, "DIARY200", "감정 투자 일기 작성 성공"),
-
+    SUCCESS_DELETE_EMOTION_DIARY(HttpStatus.OK, "DIARY2002", "감정 투자 일기가 삭제되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/synergyx/trading/controller/EmotionDiaryController.java
+++ b/src/main/java/com/synergyx/trading/controller/EmotionDiaryController.java
@@ -7,6 +7,7 @@ import com.synergyx.trading.dto.emotionDiary.EmotionDiaryResponseDTO;
 import com.synergyx.trading.service.emotionDiaryService.EmotionDiaryCommandService;
 import com.synergyx.trading.service.emotionDiaryService.EmotionDiaryQueryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +46,19 @@ public class EmotionDiaryController {
     public ResponseEntity<?> getEmotionDiaryList() {
         List<EmotionDiaryResponseDTO.EmotionDiaryDTO> result = emotionDiaryQueryService.getEmotionDiaryList(TEMP_USER_ID);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
+    // 감정 투자 일기 삭제
+    @Operation(summary = "감정 투자 일기 삭제", description = "감정 투자 일기를 삭제합니다.")
+    @DeleteMapping("/{diaryId}")
+    public ResponseEntity<?> deleteDiary(
+            @Parameter
+            @PathVariable Long diaryId) {
+        emotionDiaryCommandService.deleteDiary(TEMP_USER_ID, diaryId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                SuccessStatus.SUCCESS_DELETE_EMOTION_DIARY.getCode(),
+                SuccessStatus.SUCCESS_DELETE_EMOTION_DIARY.getMessage()
+        ));
     }
 
 }

--- a/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryCommandService.java
+++ b/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryCommandService.java
@@ -6,4 +6,7 @@ import com.synergyx.trading.dto.emotionDiary.EmotionDiaryRequestDTO;
 public interface EmotionDiaryCommandService {
     // 감정 투자 일기 작성
     EmotionDiaryResponseDTO.EmotionDiaryDTO writeDiary(Long userId, EmotionDiaryRequestDTO dto);
+
+    // 감정 투자 일기 삭제
+    void deleteDiary(Long userId, Long diaryId);
 }

--- a/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryCommandServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/emotionDiaryService/EmotionDiaryCommandServiceImpl.java
@@ -55,4 +55,21 @@ public class EmotionDiaryCommandServiceImpl implements  EmotionDiaryCommandServi
                 .build();
     }
 
+    // 감정 투자 일기 삭제
+    @Override
+    @Transactional
+    public void deleteDiary(Long userId, Long diaryId) {
+
+        // 감정 투자 일기 정보 확인
+        EmotionDiary diary = emotionDiaryRepository.findById(diaryId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.DIARY_NOT_FOUND));
+
+        // 사용자 권한 확인
+        if (!diary.getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus._FORBIDDEN);
+        }
+
+        emotionDiaryRepository.delete(diary);
+    }
+
 }


### PR DESCRIPTION
## 🚀 개요
감정 투자 일기 삭제 기능을 구현했습니다.

## 📌 관련 이슈
- Closes #67 

## ⏳ 작업 내용
- 컨트롤러 구현
- 서비스 구현
- 성공/에러 코드 추가

## 📸 스크린샷
<img width="467" height="161" alt="image" src="https://github.com/user-attachments/assets/1099be82-d45e-479f-8519-2160a787dd9d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 감정 투자 일기를 ID로 삭제할 수 있는 DELETE 엔드포인트가 추가되었습니다. 삭제 성공 시 표준 성공 코드/메시지를 반환합니다.
  * 존재하지 않는 일기 삭제 시 404 상태와 안내 메시지를 제공합니다.
  * 소유자가 아닌 사용자의 삭제 요청은 거부되어 안전한 삭제 권한이 보장됩니다.
* Documentation
  * API 문서에 DELETE /diaries/{diaryId} 엔드포인트와 요약/설명이 추가되어 사용 방법을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->