### PR TITLE
Feat/#81 add stock id to pattern detail response

### DIFF
--- a/src/main/java/com/synergyx/trading/dto/pattern/PatternResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/pattern/PatternResponseDTO.java
@@ -73,6 +73,7 @@ public class PatternResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class AppliedStockDTO {
+        private Long stockId; // 종목 아이디
         private String symbol; // 종목 코드
         private String stockName; // 종목 이름
         private String stockImage; // 종목 이미지

--- a/src/main/java/com/synergyx/trading/service/patternService/PatternQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/patternService/PatternQueryServiceImpl.java
@@ -94,6 +94,7 @@ public class PatternQueryServiceImpl implements PatternQueryService {
 
         List<PatternResponseDTO.AppliedStockDTO> appliedStocks = applyList.stream()
                 .map(apply -> PatternResponseDTO.AppliedStockDTO.builder()
+                        .stockId(apply.getStock().getId())
                         .symbol(apply.getStock().getSymbol())
                         .stockName(apply.getStock().getName())
                         .stockImage(apply.getStock().getImageUrl())


### PR DESCRIPTION
## 🚀 개요
패턴 상세 조회 시 적용한 목록 응답에 종목 id 추가했습니다.

## 📌 관련 이슈
- Closes #81 

## ⏳ 작업 내용
- dto, 서비스 수정

## 📸 스크린샷
<img width="1017" height="190" alt="image" src="https://github.com/user-attachments/assets/f4c97025-4fa7-4971-8b0b-14de9e5cc74d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 패턴 상세의 적용 종목 데이터에 종목 ID가 추가되었습니다. 이제 심볼, 종목명, 이미지와 함께 종목 ID가 제공되어 목록, 상세, 공유 등에서 일관된 식별 정보가 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->