### PR TITLE
Feat/#83 backtest candle api

### DIFF
--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
@@ -43,6 +43,7 @@ public enum ErrorStatus implements BaseErrorCode {
     BACKTEST_NOT_FOUND(HttpStatus.NOT_FOUND, "BACKTEST404", "해당 백테스트 결과가 존재하지 않습니다."),
     BACKTEST_PERIOD_EXCEEDS_LIMIT(HttpStatus.BAD_REQUEST, "BACKTEST400", "백테스트 기간은 최대 5년까지 가능합니다."),
     FASTAPI_BACKTEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BACKTEST502", "FastAPI 백테스트 서버 호출에 실패했습니다."),
+    HIGHLIGHT_RANGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "BACKTEST401", "해당 백테스트 결과에 하이라이트 구간이 존재하지 않습니다."),
 
     // 캔들 데이터 관련 예외 처리
     CANDLE_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "CANDLE404", "캔들 데이터가 존재하지 않습니다."),

--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
@@ -43,7 +43,7 @@ public enum ErrorStatus implements BaseErrorCode {
     BACKTEST_NOT_FOUND(HttpStatus.NOT_FOUND, "BACKTEST404", "해당 백테스트 결과가 존재하지 않습니다."),
     BACKTEST_PERIOD_EXCEEDS_LIMIT(HttpStatus.BAD_REQUEST, "BACKTEST400", "백테스트 기간은 최대 5년까지 가능합니다."),
     FASTAPI_BACKTEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BACKTEST502", "FastAPI 백테스트 서버 호출에 실패했습니다."),
-    HIGHLIGHT_RANGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "BACKTEST401", "해당 백테스트 결과에 하이라이트 구간이 존재하지 않습니다."),
+    HIGHLIGHT_RANGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BACKTEST4041", "해당 백테스트 결과에 하이라이트 구간이 존재하지 않습니다."),
 
     // 캔들 데이터 관련 예외 처리
     CANDLE_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "CANDLE404", "캔들 데이터가 존재하지 않습니다."),

--- a/src/main/java/com/synergyx/trading/controller/BacktestController.java
+++ b/src/main/java/com/synergyx/trading/controller/BacktestController.java
@@ -80,12 +80,12 @@ public class BacktestController {
             @Parameter(description = "백테스트 ID")
             @PathVariable Long backtestId,
             @Parameter(
-                    description = "기간의 앞뒤 여유 간격(기본값: 20, 최소: 0, 최대: 100)"
+                    description = "기간의 앞뒤 여유 간격(기본값: 20, 최소: 0)"
             )
             @RequestParam(defaultValue = "20") int margin
     ) {
         // 마진 입력값 검증
-        if (margin < 0 || margin > 100) {
+        if (margin < 0) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
         var candles = backtestService.getBacktestResultCandles(TEMP_USER_ID, backtestId, margin);

--- a/src/main/java/com/synergyx/trading/controller/BacktestController.java
+++ b/src/main/java/com/synergyx/trading/controller/BacktestController.java
@@ -80,7 +80,7 @@ public class BacktestController {
             @Parameter(description = "백테스트 ID")
             @PathVariable Long backtestId,
             @Parameter(
-                    description = "기간의 앞뒤 여유 간격(기본값: 20)"
+                    description = "기간의 앞뒤 여유 간격(기본값: 20, 최소: 0, 최대: 100)"
             )
             @RequestParam(defaultValue = "20") int margin
     ) {
@@ -88,7 +88,7 @@ public class BacktestController {
         if (margin < 0 || margin > 100) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
-        var candles = backtestService.getBacktestResultCandles(backtestId, TEMP_USER_ID, margin);
+        var candles = backtestService.getBacktestResultCandles(TEMP_USER_ID, backtestId, margin);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 candles,

--- a/src/main/java/com/synergyx/trading/controller/BacktestController.java
+++ b/src/main/java/com/synergyx/trading/controller/BacktestController.java
@@ -42,7 +42,7 @@ public class BacktestController {
     // 과거 백테스팅 결과 상세 조회
     @Operation(summary = "백테스팅 결과 상세 조회", description = "해당 백테스팅 결과의 상세 정보를 조회합니다.")
     @GetMapping("/results/{backtestId}")
-    public ResponseEntity<?>  getBacktestResultDetail(
+    public ResponseEntity<?> getBacktestResultDetail(
             @Parameter
             @PathVariable Long backtestId) {
         BacktestResponseDTO.BacktestResultDetailDTO dto = backtestService.getBacktestResultDetail(TEMP_USER_ID, backtestId);
@@ -52,7 +52,7 @@ public class BacktestController {
     // 최근 백테스팅 결과 목록 조회
     @Operation(summary = "백테스팅 결과 목록 조회", description = "최근 백테스팅 결과 목록을 조회합니다.")
     @GetMapping("/results")
-    public ResponseEntity<?>  getBacktestResultList(
+    public ResponseEntity<?> getBacktestResultList(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size) {
 
@@ -69,5 +69,25 @@ public class BacktestController {
                 .build();
 
         return ResponseEntity.ok(ApiResponse.onSuccess(dto));
+    }
+
+    // 백테스트 결과 차트 조회
+    @Operation(summary = "백테스팅 결과 차트 조회", description = "해당 백테스팅 결과의 상세 화면에 나타낼 캔들 데이터를 조회합니다. (조회 구간: 최대 수익률 구간, 마진은 선택 사항)")
+    @GetMapping("/results/{backtestId}/candles")
+    public ResponseEntity<?> getBacktestCandles(
+            @Parameter(description = "백테스트 ID")
+            @PathVariable Long backtestId,
+            @Parameter(
+                    description = "기간의 앞뒤 여유 간격(기본값: 20)"
+            )
+            @RequestParam(defaultValue = "20") int margin
+    ) {
+        var candles = backtestService.getBacktestResultCandles(backtestId, TEMP_USER_ID, margin);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                candles,
+                SuccessStatus.SUCCESS_CHART_DATA.getCode(),
+                SuccessStatus.SUCCESS_CHART_DATA.getMessage()
+        ));
     }
 }

--- a/src/main/java/com/synergyx/trading/controller/BacktestController.java
+++ b/src/main/java/com/synergyx/trading/controller/BacktestController.java
@@ -1,7 +1,9 @@
 package com.synergyx.trading.controller;
 
 import com.synergyx.trading.apiPayload.ApiResponse;
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
 import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
 import com.synergyx.trading.dto.backtest.BacktestRequestDTO;
 import com.synergyx.trading.dto.backtest.BacktestResponseDTO;
 import com.synergyx.trading.service.backtestService.BacktestService;
@@ -82,6 +84,10 @@ public class BacktestController {
             )
             @RequestParam(defaultValue = "20") int margin
     ) {
+        // 마진 입력값 검증
+        if (margin < 0 || margin > 100) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
         var candles = backtestService.getBacktestResultCandles(backtestId, TEMP_USER_ID, margin);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(

--- a/src/main/java/com/synergyx/trading/dto/backtest/BacktestResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/backtest/BacktestResponseDTO.java
@@ -1,10 +1,12 @@
 package com.synergyx.trading.dto.backtest;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.synergyx.trading.enums.PeriodUnit;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class BacktestResponseDTO  {
@@ -46,7 +48,20 @@ public class BacktestResponseDTO  {
         private Double totalReturn; // 모든 매칭 결과 누적 수익률
         private LocalDate lastMatchedDate; // 마지막 패턴 발생일
         private Double lastMatchedReturn; // 마지막 패턴 발생시 수익률
+        private HighlightRangeDTO highlightRange; // 최대 수익률 하이라이트 범위
+        private PeriodUnit periodUnit; // 단위
     }
+
+    // 백테스팅 최대 수익률 하이라이트 부분
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HighlightRangeDTO  {
+        private LocalDateTime fromDate;
+        private LocalDateTime toDate;
+    }
+
     // 백테스팅 결과 상세 조회
     @Getter
     @Builder
@@ -69,6 +84,8 @@ public class BacktestResponseDTO  {
         private Double totalReturn; // 모든 매칭 결과 누적 수익률
         private LocalDate lastMatchedDate; // 마지막 패턴 발생일
         private Double lastMatchedReturn; // 마지막 패턴 발생시 수익률
+        private HighlightRangeDTO highlightRange; // 최대 수익률 하이라이트 범위
+        private PeriodUnit periodUnit; // 단위
     }
 
     // 백테스팅 결과 목록 조회용 content
@@ -106,5 +123,4 @@ public class BacktestResponseDTO  {
             private int totalPages; // 전체 페이지 수
         }
     }
-
 }

--- a/src/main/java/com/synergyx/trading/model/Backtest.java
+++ b/src/main/java/com/synergyx/trading/model/Backtest.java
@@ -1,9 +1,11 @@
 package com.synergyx.trading.model;
 
+import com.synergyx.trading.enums.PeriodUnit;
 import com.synergyx.trading.model.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(
@@ -77,4 +79,14 @@ public class Backtest extends BaseEntity {
 
     @Column(nullable = false)
     private Double lastMatchedReturn; // 마지막 패턴 발생시 수익률
+
+    @Column(name = "highlight_from_date")
+    private LocalDateTime highlightFromDate; // 최대 수익률 발생 시 매칭 시작일
+
+    @Column(name = "highlight_to_date")
+    private LocalDateTime highlightToDate; // 최대 수익률 발생 시 매칭 종료일
+
+    @Column(name = "period_unit", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PeriodUnit periodUnit; // 기간 단위
 }

--- a/src/main/java/com/synergyx/trading/model/StockOhlcv1h.java
+++ b/src/main/java/com/synergyx/trading/model/StockOhlcv1h.java
@@ -1,6 +1,7 @@
 package com.synergyx.trading.model;
 
 import com.synergyx.trading.model.common.BaseEntity;
+import com.synergyx.trading.model.common.Ohlcv;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,7 +19,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class StockOhlcv1h extends BaseEntity {
+public class StockOhlcv1h extends BaseEntity implements Ohlcv {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/synergyx/trading/repository/BacktestRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/BacktestRepository.java
@@ -34,5 +34,5 @@ public interface BacktestRepository extends JpaRepository<Backtest, Long> {
     List<Backtest> findTop3ByPatternIdAndUserIdOrderByExecutedAtDescIdDesc(Long patternId, Long userId);
 
     // 사용자의 백테스팅 정보 조회
-    Optional<Backtest> findByIdAndUserId(Long id, Long userId);
+    Optional<Backtest> findByIdAndUserId(Long backtestId, Long userId);
 }

--- a/src/main/java/com/synergyx/trading/repository/BacktestRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/BacktestRepository.java
@@ -32,4 +32,7 @@ public interface BacktestRepository extends JpaRepository<Backtest, Long> {
 
     // 특정 패턴에 대한 최근 3개 백테스트 조회 (패턴 목록 조회용)
     List<Backtest> findTop3ByPatternIdAndUserIdOrderByExecutedAtDescIdDesc(Long patternId, Long userId);
+
+    // 사용자의 백테스팅 정보 조회
+    Optional<Backtest> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/synergyx/trading/repository/StockOhlcv1dRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/StockOhlcv1dRepository.java
@@ -17,4 +17,11 @@ public interface StockOhlcv1dRepository extends JpaRepository<StockOhlcv1d, Long
 
     // 상위 63개 ohlcv 조회 (약 3개월)
     List<StockOhlcv1d> findTop63ByStockIdOrderByTimestampDesc(Long stockId);
+
+    // 기간별 일봉 조회 (오름차순 정렬)
+    List<StockOhlcv1d> findByStockIdAndTimestampBetweenOrderByTimestampAsc(
+            Long stockId,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    );
 }

--- a/src/main/java/com/synergyx/trading/repository/StockOhlcv1hRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/StockOhlcv1hRepository.java
@@ -4,11 +4,17 @@ import com.synergyx.trading.model.StockOhlcv1h;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface StockOhlcv1hRepository extends JpaRepository<StockOhlcv1h, Long> {
 
     // 중복 방지용
     Optional<StockOhlcv1h> findByStock_IdAndTimestamp(Long stockId, LocalDateTime timestamp);
+
+    // 기간별 시간봉 조회 (오름차순 정렬)
+    List<StockOhlcv1h> findByStockIdAndTimestampBetweenOrderByTimestampAsc(
+            Long stockId, LocalDateTime start, LocalDateTime end
+    );
 }
 

--- a/src/main/java/com/synergyx/trading/service/backtestService/BacktestService.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/BacktestService.java
@@ -18,5 +18,5 @@ public interface BacktestService {
     Page<BacktestResponseDTO.BacktestSummaryDTO> getBacktestResultList(Long userId, int page, int size);
 
     // 백테스팅 결과 차트 조회
-    List<StockCandleResponseDTO> getBacktestResultCandles(Long backtestId, Long userId, int margin);
+    List<StockCandleResponseDTO> getBacktestResultCandles(Long userId, Long backtestId, int margin);
 }

--- a/src/main/java/com/synergyx/trading/service/backtestService/BacktestService.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/BacktestService.java
@@ -2,7 +2,10 @@ package com.synergyx.trading.service.backtestService;
 
 import com.synergyx.trading.dto.backtest.BacktestRequestDTO;
 import com.synergyx.trading.dto.backtest.BacktestResponseDTO;
+import com.synergyx.trading.dto.stockDetail.StockCandleResponseDTO;
 import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 public interface BacktestService {
     // 백테스팅 실행
@@ -14,4 +17,6 @@ public interface BacktestService {
     // 백테스팅 결과 목록 조회
     Page<BacktestResponseDTO.BacktestSummaryDTO> getBacktestResultList(Long userId, int page, int size);
 
+    // 백테스팅 결과 차트 조회
+    List<StockCandleResponseDTO> getBacktestResultCandles(Long backtestId, Long userId, int margin);
 }

--- a/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
@@ -129,7 +129,7 @@ public class BacktestServiceImpl implements BacktestService {
         }
 
         // 백테스팅 조회
-        Backtest backtest = backtestRepository.findById(backtestId)
+        Backtest backtest = backtestRepository.findByIdAndUserId(backtestId, userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BACKTEST_NOT_FOUND));
 
         return BacktestResponseDTO.BacktestResultDetailDTO.builder()
@@ -150,10 +150,12 @@ public class BacktestServiceImpl implements BacktestService {
                 .lastMatchedReturn(backtest.getLastMatchedReturn())
                 .totalReturn(backtest.getTotalReturn())
                 .highlightRange(
-                        BacktestResponseDTO.HighlightRangeDTO.builder()
+                        (backtest.getHighlightFromDate() != null && backtest.getHighlightToDate() != null)
+                                ? BacktestResponseDTO.HighlightRangeDTO.builder()
                                 .fromDate(backtest.getHighlightFromDate())
                                 .toDate(backtest.getHighlightToDate())
                                 .build()
+                                : null
                 )
                 .periodUnit(backtest.getPeriodUnit())
                 .build();

--- a/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
@@ -185,7 +185,7 @@ public class BacktestServiceImpl implements BacktestService {
     // 백테스팅 결과 차트 조회
     @Override
     @Transactional(readOnly = true)
-    public List<StockCandleResponseDTO> getBacktestResultCandles(Long backtestId, Long userId, int margin) {
+    public List<StockCandleResponseDTO> getBacktestResultCandles(Long userId, Long backtestId, int margin) {
 
         // 유저 존재 여부 확인
         if (!userRepository.existsById(userId)) {

--- a/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
@@ -107,10 +107,12 @@ public class BacktestServiceImpl implements BacktestService {
                 .lastMatchedDate(saved.getLastMatchedDate())
                 .lastMatchedReturn(saved.getLastMatchedReturn())
                 .highlightRange(
-                        BacktestResponseDTO.HighlightRangeDTO.builder()
+                        (saved.getHighlightFromDate() != null && saved.getHighlightToDate() != null)
+                                ? BacktestResponseDTO.HighlightRangeDTO.builder()
                                 .fromDate(saved.getHighlightFromDate())
                                 .toDate(saved.getHighlightToDate())
                                 .build()
+                                : null
                 )
                 .periodUnit(saved.getPeriodUnit())
                 .build();

--- a/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
@@ -190,7 +190,7 @@ public class BacktestServiceImpl implements BacktestService {
             throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
         }
 
-        Backtest backtest = backtestRepository.findById(backtestId)
+        Backtest backtest = backtestRepository.findByIdAndUserId(backtestId, userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BACKTEST_NOT_FOUND));
 
         if (backtest.getHighlightFromDate() == null || backtest.getHighlightToDate() == null) {

--- a/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/BacktestServiceImpl.java
@@ -3,6 +3,7 @@ import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
 import com.synergyx.trading.apiPayload.exception.GeneralException;
 import com.synergyx.trading.dto.backtest.BacktestRequestDTO;
 import com.synergyx.trading.dto.backtest.BacktestResponseDTO;
+import com.synergyx.trading.dto.stockDetail.StockCandleResponseDTO;
 import com.synergyx.trading.model.Backtest;
 import com.synergyx.trading.model.Pattern;
 import com.synergyx.trading.model.Stock;
@@ -11,6 +12,7 @@ import com.synergyx.trading.repository.BacktestRepository;
 import com.synergyx.trading.repository.PatternRepository;
 import com.synergyx.trading.repository.StockRepository;
 import com.synergyx.trading.repository.UserRepository;
+import com.synergyx.trading.service.stockService.candle.StockCandleQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.synergyx.trading.service.backtestService.client.BacktestClientService;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +34,7 @@ public class BacktestServiceImpl implements BacktestService {
     private final StockRepository stockRepository;
     private final UserRepository userRepository;
     private final BacktestClientService backtestClientService;
+    private final StockCandleQueryService stockCandleQueryService;
 
     // 백테스팅 실행
     @Override
@@ -75,6 +80,14 @@ public class BacktestServiceImpl implements BacktestService {
                 .lastMatchedDate(result.getLastMatchedDate())
                 .lastMatchedReturn(result.getLastMatchedReturn())
                 .totalReturn(result.getTotalReturn())
+                // null 허용
+                .highlightFromDate(
+                        result.getHighlightRange() != null ? result.getHighlightRange().getFromDate() : null
+                )
+                .highlightToDate(
+                        result.getHighlightRange() != null ? result.getHighlightRange().getToDate() : null
+                )
+                .periodUnit(pattern.getPeriodUnit())
                 .build());
 
         return BacktestResponseDTO.BacktestExecutionDTO.builder()
@@ -93,6 +106,13 @@ public class BacktestServiceImpl implements BacktestService {
                 .totalReturn(saved.getTotalReturn())
                 .lastMatchedDate(saved.getLastMatchedDate())
                 .lastMatchedReturn(saved.getLastMatchedReturn())
+                .highlightRange(
+                        BacktestResponseDTO.HighlightRangeDTO.builder()
+                                .fromDate(saved.getHighlightFromDate())
+                                .toDate(saved.getHighlightToDate())
+                                .build()
+                )
+                .periodUnit(saved.getPeriodUnit())
                 .build();
     }
 
@@ -101,9 +121,10 @@ public class BacktestServiceImpl implements BacktestService {
     @Transactional(readOnly = true)
     public BacktestResponseDTO.BacktestResultDetailDTO getBacktestResultDetail(Long userId, Long backtestId) {
 
-        // 사용자 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        // 유저 존재 여부 확인
+        if (!userRepository.existsById(userId)) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
 
         // 백테스팅 조회
         Backtest backtest = backtestRepository.findById(backtestId)
@@ -126,6 +147,13 @@ public class BacktestServiceImpl implements BacktestService {
                 .lastMatchedDate(backtest.getLastMatchedDate())
                 .lastMatchedReturn(backtest.getLastMatchedReturn())
                 .totalReturn(backtest.getTotalReturn())
+                .highlightRange(
+                        BacktestResponseDTO.HighlightRangeDTO.builder()
+                                .fromDate(backtest.getHighlightFromDate())
+                                .toDate(backtest.getHighlightToDate())
+                                .build()
+                )
+                .periodUnit(backtest.getPeriodUnit())
                 .build();
     }
 
@@ -134,9 +162,10 @@ public class BacktestServiceImpl implements BacktestService {
     @Transactional(readOnly = true)
     public Page<BacktestResponseDTO.BacktestSummaryDTO> getBacktestResultList(Long userId, int page, int size) {
 
-        // 사용자 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        // 유저 존재 여부 확인
+        if (!userRepository.existsById(userId)) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
 
         Pageable pageable = PageRequest.of(page, size, Sort.by("executedAt").descending());
         Page<Backtest> resultPage = backtestRepository.findByUserId(userId, pageable);
@@ -151,4 +180,38 @@ public class BacktestServiceImpl implements BacktestService {
                 .build());
     }
 
+    // 백테스팅 결과 차트 조회
+    @Override
+    @Transactional(readOnly = true)
+    public List<StockCandleResponseDTO> getBacktestResultCandles(Long backtestId, Long userId, int margin) {
+
+        // 유저 존재 여부 확인
+        if (!userRepository.existsById(userId)) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
+
+        Backtest backtest = backtestRepository.findById(backtestId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BACKTEST_NOT_FOUND));
+
+        if (backtest.getHighlightFromDate() == null || backtest.getHighlightToDate() == null) {
+            throw new GeneralException(ErrorStatus.HIGHLIGHT_RANGE_NOT_FOUND);
+        }
+
+        Long stockId = backtest.getStock().getId();
+        LocalDateTime from = backtest.getHighlightFromDate();
+        LocalDateTime to = backtest.getHighlightToDate();
+
+        return switch (backtest.getPeriodUnit()) {
+            case DAY -> stockCandleQueryService.getBacktestDailyCandles(
+                    stockId,
+                    from.toLocalDate().minusDays(margin),
+                    to.toLocalDate().plusDays(margin)
+            );
+            case HOUR -> stockCandleQueryService.getBacktestHourlyCandles(
+                    stockId,
+                    from.minusHours(margin),
+                    to.plusHours(margin)
+            );
+        };
+    }
 }

--- a/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryService.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryService.java
@@ -2,10 +2,18 @@ package com.synergyx.trading.service.stockService.candle;
 
 import com.synergyx.trading.dto.stockDetail.StockCandleResponseDTO;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface StockCandleQueryService {
 
     // 캔들 데이터 조회
     List<StockCandleResponseDTO> getCandles(Long stockId, String interval);
+
+    // 백테스팅 결과 전용 캔들 데이터 조회
+    // 일봉
+    List<StockCandleResponseDTO> getBacktestDailyCandles(Long stockId, LocalDate startDate, LocalDate endDate);
+    // 시간봉
+    List<StockCandleResponseDTO> getBacktestHourlyCandles(Long id, LocalDateTime  startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryService.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryService.java
@@ -15,5 +15,5 @@ public interface StockCandleQueryService {
     // 일봉
     List<StockCandleResponseDTO> getBacktestDailyCandles(Long stockId, LocalDate startDate, LocalDate endDate);
     // 시간봉
-    List<StockCandleResponseDTO> getBacktestHourlyCandles(Long id, LocalDateTime  startDate, LocalDateTime endDate);
+    List<StockCandleResponseDTO> getBacktestHourlyCandles(Long stockId, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryServiceImpl.java
@@ -2,12 +2,17 @@ package com.synergyx.trading.service.stockService.candle;
 
 import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
 import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.converter.StockCandleConverter;
 import com.synergyx.trading.dto.stockDetail.StockCandleResponseDTO;
 import com.synergyx.trading.enums.CandleInterval;
+import com.synergyx.trading.repository.StockOhlcv1dRepository;
+import com.synergyx.trading.repository.StockOhlcv1hRepository;
 import com.synergyx.trading.service.stockService.candle.strategy.CandleCompressionStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -43,5 +48,65 @@ public class StockCandleQueryServiceImpl implements StockCandleQueryService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.INVALID_CANDLE_INTERVAL))
                 .compress(stockId);
     }
-}
 
+    private final StockOhlcv1dRepository stockOhlcv1dRepository;
+    private final StockOhlcv1hRepository stockOhlcv1hRepository;
+    private final StockCandleConverter stockCandleConverter;
+
+    /**
+     * 백테스트 결과 차트용 일봉 데이터를 조회합니다.
+     * <p>
+     * startDate ~ endDate 구간의 캔들 데이터를 반환합니다.
+     *
+     * @param stockId   종목 ID
+     * @param startDate 시작일 (LocalDate)
+     * @param endDate   종료일 (LocalDate)
+     * @return 캔들 응답 DTO 리스트
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<StockCandleResponseDTO> getBacktestDailyCandles(Long stockId, LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+
+        LocalDateTime start = startDate.atStartOfDay();
+        LocalDateTime end = endDate.atTime(23, 59, 59);
+
+        var candles = stockOhlcv1dRepository
+                .findByStockIdAndTimestampBetweenOrderByTimestampAsc(stockId, start, end);
+
+        if (candles == null || candles.isEmpty()) {
+            throw new GeneralException(ErrorStatus.CANDLE_DATA_NOT_FOUND);
+        }
+
+        return stockCandleConverter.toDtoList(candles);
+    }
+
+    /**
+     * 백테스트 결과 차트용 시간봉 데이터를 조회합니다.
+     * <p>
+     * startDate ~ endDate 구간의 캔들 데이터를 반환합니다.
+     *
+     * @param stockId    종목 ID
+     * @param startDate  시작일시 (LocalDateTime)
+     * @param endDate    종료일시 (LocalDateTime)
+     * @return 캔들 응답 DTO 리스트
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<StockCandleResponseDTO> getBacktestHourlyCandles(Long stockId, LocalDateTime startDate, LocalDateTime endDate) {
+        if (startDate == null || endDate == null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+
+        var candles = stockOhlcv1hRepository
+                .findByStockIdAndTimestampBetweenOrderByTimestampAsc(stockId, startDate, endDate);
+
+        if (candles == null || candles.isEmpty()) {
+            throw new GeneralException(ErrorStatus.CANDLE_DATA_NOT_FOUND);
+        }
+
+        return stockCandleConverter.toDtoList(candles);
+    }
+}


### PR DESCRIPTION
## 🚀 개요
백테스팅 결과 차트 조회 api를 구현했습니다.

## 📌 관련 이슈
- Closes #83 

## ⏳ 작업 내용
- 백테스팅 모델에 하이라이트 범위, 기간 단위 추가
- 응답 dto 수정
- 에러 코드 추가
- 백테스팅 결과 차트 조회 서비스 구현
- 요청 구간에 따른 캔들 데이터 (시간봉/일봉) 반환 서비스 추가

## 📸 스크린샷
[백테스팅 실행 api 응답]
<img width="447" height="538" alt="스크린샷 2025-09-01 165846" src="https://github.com/user-attachments/assets/7df4679b-24de-4b96-9ced-5d78f76350d7" />

[백테스팅 결과 차트 조회 api 응답]
<img width="550" height="556" alt="스크린샷 2025-09-01 165902" src="https://github.com/user-attachments/assets/4146c181-e097-4814-a5dd-0772382c8640" />

[백테스팅 상세 조회 api 응답]
<img width="964" height="534" alt="스크린샷 2025-09-01 165924" src="https://github.com/user-attachments/assets/6f7059d0-fead-4193-ba4d-8939fff18c43" />

## 📝 참고 사항
- 백테스팅 아이디를 파라미터로 넘길 시 자동으로 하이라이팅 범위의 캔들 데이터를 넘겨줍니다. 
- 백테스팅 전체 기간을 캔들 차트로 넘겨주기에 과부화가 심해서 기간 대신 백테스팅 아이디와 마진을 받습니다.
- 파라미터에 마진도 있는데, 선택입니다. 고정값은 20입니다.
- 만약 패턴 단위가 시간일 경우, 앞 뒤 각각 20시간씩 더 보내줍니다. 
- 만약 패턴 단위가 일일 경우, 앞 뒤 각각 20일씩 더 보내줍니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 백테스트 결과의 캔들 차트 조회 엔드포인트 추가(기본 margin=20, margin 범위 검증).
  - 백테스트 응답에 하이라이트 구간(from/to) 및 기간 단위(일/시간) 포함.

- **개선**
  - 일봉·시간봉 데이터가 시간순 정렬되어 차트 가독성 향상.
  - 사용자 존재 검증 강화로 안정성 향상.

- **오류 처리**
  - 하이라이트 구간 없음에 대한 명확한 오류 코드/메시지 추가.
  - 캔들 데이터 없을 시 적절한 오류 반환.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->