### PR TITLE
[FEAT] 15분봉을 1시간봉으로 리샘플링하는 로직 추가 #86

### DIFF
--- a/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryServiceImpl.java
@@ -5,15 +5,19 @@ import com.synergyx.trading.apiPayload.exception.GeneralException;
 import com.synergyx.trading.converter.StockCandleConverter;
 import com.synergyx.trading.dto.stockDetail.StockCandleResponseDTO;
 import com.synergyx.trading.enums.CandleInterval;
+import com.synergyx.trading.model.StockOhlcv;
 import com.synergyx.trading.repository.StockOhlcv1dRepository;
-import com.synergyx.trading.repository.StockOhlcv1hRepository;
+import com.synergyx.trading.repository.StockOhlcvRepository;
 import com.synergyx.trading.service.stockService.candle.strategy.CandleCompressionStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import java.util.TreeMap;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,8 +53,8 @@ public class StockCandleQueryServiceImpl implements StockCandleQueryService {
                 .compress(stockId);
     }
 
+    private final StockOhlcvRepository stockOhlcvRepository;
     private final StockOhlcv1dRepository stockOhlcv1dRepository;
-    private final StockOhlcv1hRepository stockOhlcv1hRepository;
     private final StockCandleConverter stockCandleConverter;
 
     /**
@@ -100,13 +104,34 @@ public class StockCandleQueryServiceImpl implements StockCandleQueryService {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
 
-        var candles = stockOhlcv1hRepository
+        // 15분봉 데이터 조회
+        var candles15m = stockOhlcvRepository
                 .findByStockIdAndTimestampBetweenOrderByTimestampAsc(stockId, startDate, endDate);
 
-        if (candles == null || candles.isEmpty()) {
+        if (candles15m == null || candles15m.isEmpty()) {
             throw new GeneralException(ErrorStatus.CANDLE_DATA_NOT_FOUND);
         }
 
-        return stockCandleConverter.toDtoList(candles);
+        // 15분봉 -> 1시간봉 리샘플링
+        Map<LocalDateTime, List<StockOhlcv>> grouped = candles15m.stream()
+                .collect(Collectors.groupingBy(
+                        c -> c.getTimestamp().withMinute(0).withSecond(0).withNano(0),
+                        TreeMap::new,
+                        Collectors.toList()
+                ));
+
+        return grouped.entrySet().stream()
+                .map(entry -> {
+                    List<StockOhlcv> group = entry.getValue();
+                    return StockCandleResponseDTO.builder()
+                            .time(entry.getKey())
+                            .open(group.get(0).getOpen())
+                            .high(group.stream().mapToDouble(StockOhlcv::getHigh).max().orElse(0))
+                            .low(group.stream().mapToDouble(StockOhlcv::getLow).min().orElse(0))
+                            .close(group.get(group.size() - 1).getClose())
+                            .volume(group.stream().mapToLong(StockOhlcv::getVolume).sum())
+                            .build();
+                })
+                .toList();
     }
 }

--- a/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/candle/StockCandleQueryServiceImpl.java
@@ -112,10 +112,11 @@ public class StockCandleQueryServiceImpl implements StockCandleQueryService {
             throw new GeneralException(ErrorStatus.CANDLE_DATA_NOT_FOUND);
         }
 
+
         // 15분봉 -> 1시간봉 리샘플링
         Map<LocalDateTime, List<StockOhlcv>> grouped = candles15m.stream()
                 .collect(Collectors.groupingBy(
-                        c -> c.getTimestamp().withMinute(0).withSecond(0).withNano(0),
+                        c -> c.getTimestamp().truncatedTo(java.time.temporal.ChronoUnit.HOURS),
                         TreeMap::new,
                         Collectors.toList()
                 ));
@@ -123,6 +124,7 @@ public class StockCandleQueryServiceImpl implements StockCandleQueryService {
         return grouped.entrySet().stream()
                 .map(entry -> {
                     List<StockOhlcv> group = entry.getValue();
+                    group.sort(java.util.Comparator.comparing(StockOhlcv::getTimestamp));
                     return StockCandleResponseDTO.builder()
                             .time(entry.getKey())
                             .open(group.get(0).getOpen())


### PR DESCRIPTION
## 🚀 개요
15분봉을 1시간봉으로 리샘플링하는 로직을 추가했습니다.

## 📌 관련 이슈
- Closes #86 

## ⏳ 작업 내용
- 기존 1시간 봉 데이터가 부족하여 15분봉 데이터를 불러와서 리샘플링 하도록 수정

## 📸 스크린샷
<img width="446" height="549" alt="스크린샷 2025-09-02 190908" src="https://github.com/user-attachments/assets/ce737ba5-eda4-4d25-afc1-4a392a59eece" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 백테스트용 시간봉 데이터가 15분봉 집계를 기반으로 산출되어 시가/고가/저가/종가/거래량 정확도가 개선되었습니다.
  - 시간 정렬과 그룹화 과정이 안정화되어 간헐적 정렬 오류와 누락 상황이 감소했습니다.
  - 관련 데이터 부재 시 명확한 오류 응답을 제공해 예측 가능한 동작을 보장합니다.
- Refactor
  - 캔들 집계 로직을 간소화하고 일관성을 높여 향후 유지보수성과 확장성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->