### PR TITLE
[FEAT] 회원가입, 로그인, 로그아웃 구현 #85

### DIFF
--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/ErrorStatus.java
@@ -63,6 +63,12 @@ public enum ErrorStatus implements BaseErrorCode {
     IMAGE_FILE_MISSING(HttpStatus.BAD_REQUEST, "IMAGE4001", "업로드된 이미지가 없습니다."),
     IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "IMAGE4002", "업로드 가능한 최대 용량은 5MB입니다."),
     INVALID_IMAGE_FILE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE4003", "지원하지 않는 이미지 형식입니다."),
+
+    // 인증 관련 예외 처리
+    AUTH_DUPLICATE_EMAIL(HttpStatus.CONFLICT, "AUTH4001", "이미 사용 중인 이메일입니다."),
+    AUTH_INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "AUTH4002", "올바른 이메일 형식이 아닙니다."),
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4003", "인증 정보가 유효하지 않습니다."),
+    AUTH_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH4004", "이메일 또는 비밀번호가 잘못되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
@@ -48,6 +48,11 @@ public enum SuccessStatus implements BaseCode {
     // 감정 투자 일기
     SUCCESS_WRITE_EMOTION_DIARY(HttpStatus.OK, "DIARY200", "감정 투자 일기 작성 성공"),
     SUCCESS_DELETE_EMOTION_DIARY(HttpStatus.OK, "DIARY2002", "감정 투자 일기가 삭제되었습니다."),
+
+    // 인증
+    AUTH_LOGIN_SUCCESS(HttpStatus.OK, "AUTH200", "로그인 성공"),
+    AUTH_SIGNUP_SUCCESS(HttpStatus.OK, "AUTH201", "회원가입 성공"),
+    AUTH_LOGOUT_SUCCESS(HttpStatus.OK, "AUTH202", "로그아웃 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/synergyx/trading/config/context/SecurityUserContext.java
+++ b/src/main/java/com/synergyx/trading/config/context/SecurityUserContext.java
@@ -1,0 +1,46 @@
+package com.synergyx.trading.config.context;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.config.security.UserAuthentication;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SecurityUserContext implements UserContext {
+
+    /**
+     * 현재 인증된 User의 Id를 가져옵니다.
+     */
+    @Override
+    public Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null) {
+            log.warn("[SecurityUserContext] 인증 객체가 null입니다.");
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
+        if (!(authentication instanceof UserAuthentication)) {
+            log.warn("[SecurityUserContext] 인증 객체 타입이 예상과 다릅니다. 현재 타입: {}",
+                    authentication.getClass().getName());
+            log.debug("[SecurityUserContext] authentication 전체 정보: {}", authentication);
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
+        UserAuthentication userAuthentication = (UserAuthentication) authentication;
+        Long userId = userAuthentication.getUserId();
+
+        if (userId == null) {
+            log.warn("[SecurityUserContext] 인증된 사용자 ID가 null입니다.");
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
+        return userId;
+    }
+}

--- a/src/main/java/com/synergyx/trading/config/context/UserContext.java
+++ b/src/main/java/com/synergyx/trading/config/context/UserContext.java
@@ -1,0 +1,5 @@
+package com.synergyx.trading.config.context;
+
+public interface UserContext {
+    Long getCurrentUserId();
+}

--- a/src/main/java/com/synergyx/trading/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/synergyx/trading/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.synergyx.trading.config.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/synergyx/trading/config/security/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/synergyx/trading/config/security/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package com.synergyx.trading.config.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/synergyx/trading/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/synergyx/trading/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,149 @@
+package com.synergyx.trading.config.security;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.config.token.JwtTokenProvider;
+import com.synergyx.trading.model.User;
+import com.synergyx.trading.repository.UserRepository;
+import com.synergyx.trading.util.ErrorResponseUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    // no auth 허용 url
+    private static final List<String> NO_AUTH_URLS = List.of(
+            "/auth/login/**",
+            "/auth/signup/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/test/**"
+    );
+
+    /**
+     * JWT 인증 필터 처리 메서드
+     * <p>
+     * Access Token을 추출하고, 토큰 유효성을 검증합니다.
+     * SecurityContext에 인증 정보를 등록합니다.
+     * 유효하지 않은 토큰의 경우 {@link ErrorResponseUtil} 을 통해 인증 실패 응답을 반환합니다.
+     *
+     * @param request
+     * @param response
+     * @param filterChain
+     * @throws ServletException
+     * @throws IOException
+     */
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String requestURI = request.getRequestURI();
+        log.info("Request URI: {}", request.getRequestURI());
+
+        // 인증이 필요 없는 URI 필터 통과
+        if (isExcludedPath(requestURI)) {
+            log.debug("[JWT] 필터 제외 대상: {}", requestURI);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String header = request.getHeader("Authorization");
+        // 401 error
+        if (header == null || !header.startsWith("Bearer ")) {
+            log.warn("[JWT] Authorization 헤더 없음 또는 형식 오류 - IP: {}", request.getRemoteAddr());
+            sendUnauthorized(response);
+            return;
+        }
+
+        // JWT 추출
+        String token = header.substring(7);
+        if (token.isBlank()) {
+            log.warn("[JWT] 토큰이 비어 있음");
+            sendUnauthorized(response);
+            return;
+        }
+
+        try {
+//            log.debug("Extracted JWT: {}", token);
+
+            // validate
+            JwtValidationType result = jwtTokenProvider.validateToken(token);
+
+            if (result != JwtValidationType.VALID_JWT) {
+                // Invalid token 관련 디테일 로그
+                log.warn("[JWT] 인증 실패 - validationType: {}, user-agent: {}", result.name(), request.getHeader("User-Agent"));
+                throw new GeneralException(ErrorStatus.AUTH_INVALID_TOKEN);
+            }
+
+            Long userId = jwtTokenProvider.parseUserId(token);
+
+            // DB에서 AccessToken 일치여부 확인
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.AUTH_INVALID_TOKEN));
+
+            if (user.getAccessToken() == null || !user.getAccessToken().equals(token)) {
+                log.warn("[JWT] DB에 저장된 토큰과 불일치 - userId={}", userId);
+                throw new GeneralException(ErrorStatus.AUTH_INVALID_TOKEN);
+            }
+
+            // authentication 생성 -> principal에 userId 저장
+            UserAuthentication authentication = new UserAuthentication(userId, null, null);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            filterChain.doFilter(request, response);
+
+        } catch (GeneralException exception) {
+            // Invalid token 관련 응답 통일
+            sendUnauthorized(response);
+        } catch (Exception exception) {
+            log.error("JWT 처리 중 알 수 없는 에러: {}", exception.getMessage(), exception);
+            // Invalid token 관련 응답 통일
+            sendUnauthorized(response);
+        }
+    }
+
+    /**
+     * URI가 인증 제외 경로인지 확인합니다.
+     *
+     * @param requestURI
+     * @return
+     */
+    private boolean isExcludedPath(String requestURI) {
+        return NO_AUTH_URLS.stream().anyMatch(pattern -> pathMatcher.match(pattern, requestURI));
+    }
+
+    /**
+     * 인증 실패 응답을 클라이언트에 전송합니다.
+     * <p>
+     * 공통 응답 포맷 형식을 사용합니다.
+     *
+     * @param response
+     * @throws IOException
+     */
+    private void sendUnauthorized(HttpServletResponse response) throws IOException {
+        SecurityContextHolder.clearContext(); // 인증 정보 제거
+        ErrorResponseUtil.writeErrorResponse(response, ErrorStatus.AUTH_INVALID_TOKEN);
+    }
+}

--- a/src/main/java/com/synergyx/trading/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/synergyx/trading/config/security/JwtAuthenticationFilter.java
@@ -20,7 +20,9 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
+import java.util.Collections;
 
 @Slf4j
 @Component
@@ -108,7 +110,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             // authentication 생성 -> principal에 userId 저장
-            UserAuthentication authentication = new UserAuthentication(userId, null, null);
+            UserAuthentication authentication = new UserAuthentication(userId, null, Collections.emptyList());
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authentication);
 

--- a/src/main/java/com/synergyx/trading/config/security/JwtValidationType.java
+++ b/src/main/java/com/synergyx/trading/config/security/JwtValidationType.java
@@ -1,0 +1,10 @@
+package com.synergyx.trading.config.security;
+
+public enum JwtValidationType {
+    VALID_JWT,              // 유효한 JWT
+    INVALID_JWT_SIGNATURE,      // 유효하지 않은 서명
+    INVALID_JWT_TOKEN,          // 유효하지 않은 토큰
+    EXPIRED_JWT_TOKEN,          // 만료된 토큰
+    UNSUPPORTED_JWT_TOKEN,      // 지원하지 않는 형식의 토큰
+    EMPTY_JWT                   // 빈 JWT
+}

--- a/src/main/java/com/synergyx/trading/config/security/SecurityConfig.java
+++ b/src/main/java/com/synergyx/trading/config/security/SecurityConfig.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -14,10 +16,19 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
     private static final String[] AUTH_WHITELIST = {
             "/auth/signup",
             "/auth/login",
-            "/**"
+            "/test/**"
     };
 
     private static final String[] SWAGGER_WHITELIST = {
@@ -34,12 +45,15 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .exceptionHandling(exception -> {
+                    exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
+                    exception.accessDeniedHandler(customAccessDeniedHandler);
                 })
                 .authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITELIST).permitAll();
                     auth.requestMatchers(SWAGGER_WHITELIST).permitAll();
                     auth.anyRequest().authenticated();
-                });
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/synergyx/trading/config/security/UserAuthentication.java
+++ b/src/main/java/com/synergyx/trading/config/security/UserAuthentication.java
@@ -1,0 +1,36 @@
+package com.synergyx.trading.config.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    /**
+     * 인증된 사용자를 생성합니다.
+     *
+     * @param userId      사용자 ID (Principal로 사용)
+     * @param credentials 인증 자격 정보 (일반적으로 null)
+     * @param authorities 권한 목록 (ROLE_USER 등)
+     */
+    public UserAuthentication(Long userId,
+                              Object credentials,
+                              Collection<? extends GrantedAuthority> authorities) {
+        super(userId, credentials, authorities);
+    }
+
+    /**
+     * 인증된 사용자 ID를 반환합니다.
+     *
+     * @return userId (Long)
+     * @throws IllegalStateException principal이 Long이 아닐 경우
+     */
+    public Long getUserId() {
+        Object principal = getPrincipal();
+        if (principal instanceof Long) {
+            return (Long) principal;
+        }
+        throw new IllegalStateException("Authentication principal is not a Long (userId).");
+    }
+}

--- a/src/main/java/com/synergyx/trading/config/token/JwtTokenProvider.java
+++ b/src/main/java/com/synergyx/trading/config/token/JwtTokenProvider.java
@@ -1,0 +1,143 @@
+package com.synergyx.trading.config.token;
+
+import com.synergyx.trading.config.security.JwtValidationType;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final String USER_ID = "userId";
+    private static final Long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24; // 1일
+
+    @Value("${auth.jwt.secret}")
+    private String JWT_SECRET;
+
+    private SecretKey signingKey;
+
+    @PostConstruct
+    protected void init() {
+        byte[] decodedKey = Base64.getUrlDecoder().decode(JWT_SECRET);
+        this.signingKey = Keys.hmacShaKeyFor(decodedKey);
+        log.debug("[JWT] Signing key initialized (Base64-decoded)");
+    }
+
+    /**
+     * AccessToken을 생성합니다.
+     */
+    public String generateAccessToken(Long userId) {
+        return generateToken(userId, ACCESS_TOKEN_EXPIRE_TIME, "ACCESS");
+    }
+
+    /**
+     * JWT를 생성합니다.
+     *
+     * @param userId
+     * @param expiryMillis
+     * @param tokenType
+     * @return
+     */
+    public String generateToken(Long userId, long expiryMillis, String tokenType) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expiryMillis);
+
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(expiryDate);  // 만료 시간 설정
+        claims.put(USER_ID, userId);
+
+//        log.info("Claims before signing: {}", claims); // JWT 생성 전 Claims 확인
+
+        String jwt = Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
+                .setClaims(claims) // Claim
+                .signWith(getSigningKey()) // Signature
+                .compact();
+
+        log.info("[JWT] {} Token 생성 - userId={}, 만료시각: {}", tokenType, userId, expiryDate);
+        return jwt;
+    }
+
+    private SecretKey getSigningKey() {
+        return signingKey;
+    }
+
+    /**
+     * 토큰의 유효성을 검증합니다.
+     *
+     * @param token
+     * @return
+     */
+    public JwtValidationType validateToken(String token) {
+//        log.info("JWT Validation Result: {}", token);
+        try {
+            final Claims claims = getTokenBody(token);
+            return JwtValidationType.VALID_JWT;
+        } catch (SignatureException ex) {
+            return JwtValidationType.INVALID_JWT_SIGNATURE;
+        } catch (MalformedJwtException ex) {
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            return JwtValidationType.EXPIRED_JWT_TOKEN;
+        } catch (UnsupportedJwtException ex) {
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    /**
+     * JWT에서 userId를 추출합니다.
+     */
+    public Long parseUserId(String token) {
+        if (!StringUtils.hasText(token)) {
+            throw new IllegalArgumentException("JWT is null or empty");
+        }
+
+        Claims claims = getTokenBody(token);
+        Object userIdObj = claims.get(USER_ID);
+
+        if (userIdObj == null) {
+            throw new IllegalArgumentException("Invalid JWT: missing userId");
+        }
+
+        try {
+            return Long.parseLong(userIdObj.toString());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid userId format in JWT");
+        }
+    }
+
+    /**
+     * JWT Body를 추출합니다. (Claims 파싱)
+     */
+    private Claims getTokenBody(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(signingKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    /**
+     * 액세스 토큰 만료 시간을 초 단위로 반환합니다.
+     */
+    public Long getAccessTokenExpirySeconds() {
+        return ACCESS_TOKEN_EXPIRE_TIME / 1000L;
+    }
+
+}
+

--- a/src/main/java/com/synergyx/trading/controller/AuthController.java
+++ b/src/main/java/com/synergyx/trading/controller/AuthController.java
@@ -7,7 +7,6 @@ import com.synergyx.trading.dto.user.LoginRequestDTO;
 import com.synergyx.trading.dto.user.LoginResponseDTO;
 import com.synergyx.trading.dto.user.SignupRequestDTO;
 import com.synergyx.trading.service.userService.UserAuthService;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -32,13 +31,12 @@ public class AuthController {
     @PostMapping("/signup")
     @Operation(summary = "회원가입",
             description = "새로운 계정을 생성합니다.")
-    public ResponseEntity<ApiResponse<SignupRequestDTO>> signup(
+    public ResponseEntity<ApiResponse<Void>> signup(
             @Valid @RequestBody SignupRequestDTO request
     ) {
         userAuthService.createUser(request);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(
-                null,
                 SuccessStatus.AUTH_SIGNUP_SUCCESS.getCode(),
                 SuccessStatus.AUTH_SIGNUP_SUCCESS.getMessage()
         ));
@@ -72,7 +70,6 @@ public class AuthController {
         userAuthService.logout(userId);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(
-                null,
                 SuccessStatus.AUTH_LOGOUT_SUCCESS.getCode(),
                 SuccessStatus.AUTH_LOGOUT_SUCCESS.getMessage()
         ));

--- a/src/main/java/com/synergyx/trading/controller/AuthController.java
+++ b/src/main/java/com/synergyx/trading/controller/AuthController.java
@@ -1,0 +1,80 @@
+package com.synergyx.trading.controller;
+
+import com.synergyx.trading.apiPayload.ApiResponse;
+import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
+import com.synergyx.trading.config.context.UserContext;
+import com.synergyx.trading.dto.user.LoginRequestDTO;
+import com.synergyx.trading.dto.user.LoginResponseDTO;
+import com.synergyx.trading.dto.user.SignupRequestDTO;
+import com.synergyx.trading.service.userService.UserAuthService;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+@Tag(name = "인증 API", description = "인증 API 입니다.")
+public class AuthController {
+
+    private final UserContext userContext;
+    private final UserAuthService userAuthService;
+
+    @PostMapping("/signup")
+    @Operation(summary = "회원가입",
+            description = "새로운 계정을 생성합니다.")
+    public ResponseEntity<ApiResponse<SignupRequestDTO>> signup(
+            @Valid @RequestBody SignupRequestDTO request
+    ) {
+        userAuthService.createUser(request);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                null,
+                SuccessStatus.AUTH_SIGNUP_SUCCESS.getCode(),
+                SuccessStatus.AUTH_SIGNUP_SUCCESS.getMessage()
+        ));
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인",
+            description = "생성된 계정에 로그인하여 JWT를 발급받는 API입니다.")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> login(
+            @Valid @RequestBody LoginRequestDTO request
+    ) {
+        String email = request.email();
+        String password = request.password();
+
+        LoginResponseDTO loginResponse = userAuthService.login(email, password);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                loginResponse,
+                SuccessStatus.AUTH_LOGIN_SUCCESS.getCode(),
+                SuccessStatus.AUTH_LOGIN_SUCCESS.getMessage()
+        ));
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃",
+            description = "현재 로그인된 사용자의 JWT를 무효화하는 API입니다.")
+    public ResponseEntity<ApiResponse<Void>> logout(
+    ) {
+        Long userId = userContext.getCurrentUserId();
+
+        userAuthService.logout(userId);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                null,
+                SuccessStatus.AUTH_LOGOUT_SUCCESS.getCode(),
+                SuccessStatus.AUTH_LOGOUT_SUCCESS.getMessage()
+        ));
+    }
+}

--- a/src/main/java/com/synergyx/trading/controller/BacktestController.java
+++ b/src/main/java/com/synergyx/trading/controller/BacktestController.java
@@ -4,6 +4,7 @@ import com.synergyx.trading.apiPayload.ApiResponse;
 import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
 import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
 import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.config.context.UserContext;
 import com.synergyx.trading.dto.backtest.BacktestRequestDTO;
 import com.synergyx.trading.dto.backtest.BacktestResponseDTO;
 import com.synergyx.trading.service.backtestService.BacktestService;
@@ -21,9 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "백테스팅 API", description = "백테스팅 관련 API 입니다.")
 public class BacktestController {
 
-    // 임시 userId
-    private static final Long TEMP_USER_ID = 1L;
-
+    private final UserContext userContext;
     private final BacktestService backtestService;
 
     // 백테스트 실행
@@ -33,7 +32,8 @@ public class BacktestController {
             @RequestParam Long patternId,
             @RequestParam Long stockId,
             @RequestBody BacktestRequestDTO request) {
-        BacktestResponseDTO.BacktestExecutionDTO result = backtestService.runBacktest(TEMP_USER_ID, patternId, stockId, request);
+        Long userId = userContext.getCurrentUserId();
+        BacktestResponseDTO.BacktestExecutionDTO result = backtestService.runBacktest(userId, patternId, stockId, request);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 result,
                 SuccessStatus.SUCCESS_BACKTEST_EXECUTE.getCode(),
@@ -47,7 +47,8 @@ public class BacktestController {
     public ResponseEntity<?> getBacktestResultDetail(
             @Parameter
             @PathVariable Long backtestId) {
-        BacktestResponseDTO.BacktestResultDetailDTO dto = backtestService.getBacktestResultDetail(TEMP_USER_ID, backtestId);
+        Long userId = userContext.getCurrentUserId();
+        BacktestResponseDTO.BacktestResultDetailDTO dto = backtestService.getBacktestResultDetail(userId, backtestId);
         return ResponseEntity.ok(ApiResponse.onSuccess(dto));
     }
 
@@ -58,7 +59,8 @@ public class BacktestController {
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size) {
 
-        Page<BacktestResponseDTO.BacktestSummaryDTO> resultPage = backtestService.getBacktestResultList(TEMP_USER_ID, page - 1, size);
+        Long userId = userContext.getCurrentUserId();
+        Page<BacktestResponseDTO.BacktestSummaryDTO> resultPage = backtestService.getBacktestResultList(userId, page - 1, size);
 
         BacktestResponseDTO.BacktestResultListDTO dto = BacktestResponseDTO.BacktestResultListDTO.builder()
                 .content(resultPage.getContent())
@@ -88,7 +90,8 @@ public class BacktestController {
         if (margin < 0) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
-        var candles = backtestService.getBacktestResultCandles(TEMP_USER_ID, backtestId, margin);
+        Long userId = userContext.getCurrentUserId();
+        var candles = backtestService.getBacktestResultCandles(userId, backtestId, margin);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 candles,

--- a/src/main/java/com/synergyx/trading/controller/EmotionDiaryController.java
+++ b/src/main/java/com/synergyx/trading/controller/EmotionDiaryController.java
@@ -2,6 +2,7 @@ package com.synergyx.trading.controller;
 
 import com.synergyx.trading.apiPayload.ApiResponse;
 import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
+import com.synergyx.trading.config.context.UserContext;
 import com.synergyx.trading.dto.emotionDiary.EmotionDiaryRequestDTO;
 import com.synergyx.trading.dto.emotionDiary.EmotionDiaryResponseDTO;
 import com.synergyx.trading.service.emotionDiaryService.EmotionDiaryCommandService;
@@ -21,9 +22,7 @@ import java.util.List;
 @Tag(name = "감정 투자 일기 API", description = "감정 투자 일기 관련 API 입니다.")
 public class EmotionDiaryController {
 
-    // 임시 userId
-    private static final Long TEMP_USER_ID = 1L;
-
+    private final UserContext userContext;
     private final EmotionDiaryCommandService emotionDiaryCommandService;
     private final EmotionDiaryQueryService emotionDiaryQueryService;
 
@@ -32,7 +31,8 @@ public class EmotionDiaryController {
     @PostMapping
     public ResponseEntity<?> writeDiary(
            @Valid @RequestBody EmotionDiaryRequestDTO request) {
-        EmotionDiaryResponseDTO.EmotionDiaryDTO result = emotionDiaryCommandService.writeDiary(TEMP_USER_ID, request);
+        Long userId = userContext.getCurrentUserId();
+        EmotionDiaryResponseDTO.EmotionDiaryDTO result = emotionDiaryCommandService.writeDiary(userId, request);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 result,
                 SuccessStatus.SUCCESS_WRITE_EMOTION_DIARY.getCode(),
@@ -44,7 +44,8 @@ public class EmotionDiaryController {
     @Operation(summary = "감정 투자 일기 목록 조회", description = "감정 투자 일기 전체를 조회합니다.")
     @GetMapping
     public ResponseEntity<?> getEmotionDiaryList() {
-        List<EmotionDiaryResponseDTO.EmotionDiaryDTO> result = emotionDiaryQueryService.getEmotionDiaryList(TEMP_USER_ID);
+        Long userId = userContext.getCurrentUserId();
+        List<EmotionDiaryResponseDTO.EmotionDiaryDTO> result = emotionDiaryQueryService.getEmotionDiaryList(userId);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
@@ -54,7 +55,8 @@ public class EmotionDiaryController {
     public ResponseEntity<?> deleteDiary(
             @Parameter
             @PathVariable Long diaryId) {
-        emotionDiaryCommandService.deleteDiary(TEMP_USER_ID, diaryId);
+        Long userId = userContext.getCurrentUserId();
+        emotionDiaryCommandService.deleteDiary(userId, diaryId);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 SuccessStatus.SUCCESS_DELETE_EMOTION_DIARY.getCode(),
                 SuccessStatus.SUCCESS_DELETE_EMOTION_DIARY.getMessage()

--- a/src/main/java/com/synergyx/trading/controller/InterestStockController.java
+++ b/src/main/java/com/synergyx/trading/controller/InterestStockController.java
@@ -2,6 +2,7 @@ package com.synergyx.trading.controller;
 
 import com.synergyx.trading.apiPayload.ApiResponse;
 import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
+import com.synergyx.trading.config.context.UserContext;
 import com.synergyx.trading.dto.InterestStock.InterestStockResponseDTO;
 import com.synergyx.trading.service.InterestStockService.InterestStockCommandService;
 import com.synergyx.trading.service.InterestStockService.InterestStockQueryService;
@@ -20,9 +21,7 @@ import java.util.List;
 @Tag(name = "관심종목 API", description = "관심종목 관련 API 입니다.")
 public class InterestStockController {
 
-    // 임시 userId
-    private static final Long TEMP_USER_ID = 1L;
-
+    private final UserContext userContext;
     private final InterestStockCommandService interestStockCommandService;
     private final InterestStockQueryService interestStockQueryService;
 
@@ -31,7 +30,8 @@ public class InterestStockController {
     public ResponseEntity<?> addWatchlist(
             @Parameter
             @PathVariable Long stockId) {
-        interestStockCommandService.addInterest(TEMP_USER_ID, stockId);
+        Long userId = userContext.getCurrentUserId();
+        interestStockCommandService.addInterest(userId, stockId);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 SuccessStatus.SUCCESS_WATCHLIST_ADD.getCode(),
                 SuccessStatus.SUCCESS_WATCHLIST_ADD.getMessage()
@@ -43,7 +43,8 @@ public class InterestStockController {
     public ResponseEntity<?> removeWatchlist(
             @Parameter
             @PathVariable Long stockId) {
-        interestStockCommandService.removeInterest(TEMP_USER_ID, stockId);
+        Long userId = userContext.getCurrentUserId();
+        interestStockCommandService.removeInterest(userId, stockId);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 SuccessStatus.SUCCESS_WATCHLIST_REMOVE.getCode(),
                 SuccessStatus.SUCCESS_WATCHLIST_REMOVE.getMessage()
@@ -53,14 +54,16 @@ public class InterestStockController {
     @Operation(summary = "관심종목 목록 조회", description = "현재 등록된 관심종목 목록을 조회합니다.")
     @GetMapping("/watchlist")
     public ResponseEntity<?> getWatchlist() {
-        List<InterestStockResponseDTO> list = interestStockQueryService.getInterestList(TEMP_USER_ID);
+        Long userId = userContext.getCurrentUserId();
+        List<InterestStockResponseDTO> list = interestStockQueryService.getInterestList(userId);
         return ResponseEntity.ok(ApiResponse.onSuccess(list));
     }
 
     @Operation(summary = "최근 조회 종목 리스트 조회", description = "최근 조회한 종목 리스트를 조회합니다. (최대 20개)")
     @GetMapping("/stocks/recent")
     public ResponseEntity<?> getRecentViewStockList() {
-        List<InterestStockResponseDTO> list = interestStockQueryService.getRecentViewStocks(TEMP_USER_ID);
+        Long userId = userContext.getCurrentUserId();
+        List<InterestStockResponseDTO> list = interestStockQueryService.getRecentViewStocks(userId);
         return ResponseEntity.ok(ApiResponse.onSuccess(list));
     }
 }

--- a/src/main/java/com/synergyx/trading/controller/NotificationController.java
+++ b/src/main/java/com/synergyx/trading/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package com.synergyx.trading.controller;
 
 import com.synergyx.trading.apiPayload.ApiResponse;
+import com.synergyx.trading.config.context.UserContext;
 import com.synergyx.trading.dto.notification.NotificationRequestDTO;
 import com.synergyx.trading.dto.notification.NotificationResponseDTO;
 import com.synergyx.trading.service.notificationService.NotificationService;
@@ -21,9 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "알림 API", description = "알림 관련 API 입니다.")
 public class NotificationController {
 
-    // 임시 userId
-    private static final Long TEMP_USER_ID = 1L;
-
+    private final UserContext userContext;
     private final NotificationService notificationService;
 
     @Operation(summary = "알림 푸시 및 저장",
@@ -33,7 +32,8 @@ public class NotificationController {
     public ResponseEntity<?> sendAndSaveNotification(
             @RequestBody @Valid NotificationRequestDTO request
     ) {
-        NotificationResponseDTO result = notificationService.sendAndSaveNotification(TEMP_USER_ID, request);
+        Long userId = userContext.getCurrentUserId();
+        NotificationResponseDTO result = notificationService.sendAndSaveNotification(userId, request);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 result,

--- a/src/main/java/com/synergyx/trading/controller/PatternApplyController.java
+++ b/src/main/java/com/synergyx/trading/controller/PatternApplyController.java
@@ -2,6 +2,7 @@ package com.synergyx.trading.controller;
 
 import com.synergyx.trading.apiPayload.ApiResponse;
 import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
+import com.synergyx.trading.config.context.UserContext;
 import com.synergyx.trading.dto.patternApply.PatternApplyRequestDTO;
 import com.synergyx.trading.dto.patternApply.PatternApplyResponseDTO;
 import com.synergyx.trading.service.patternApplyService.PatternApplyCommandService;
@@ -20,9 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/pattern-applies")
 public class PatternApplyController {
 
-    // 임시 userId
-    private static final Long TEMP_USER_ID = 1L;
-
+    private final UserContext userContext;
     private final PatternApplyCommandService patternApplyCommandService;
     private final PatternApplyQueryService patternApplyQueryService;
 
@@ -31,8 +30,9 @@ public class PatternApplyController {
     @PostMapping
     public ResponseEntity<?> applyPattern(
             @RequestBody PatternApplyRequestDTO.PatternApplyDTO request) {
+        Long userId = userContext.getCurrentUserId();
         PatternApplyResponseDTO.PatternApplyResultDTO response =
-                patternApplyCommandService.applyPattern(TEMP_USER_ID, request);
+                patternApplyCommandService.applyPattern(userId, request);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 response,
                 SuccessStatus.SUCCESS_PATTERN_APPLY.getCode(),
@@ -45,8 +45,9 @@ public class PatternApplyController {
     @PatchMapping("/{patternApplyId}/notification")
     public ResponseEntity<?>toggleNotification(
             @PathVariable @Valid @Positive Long patternApplyId) {
+        Long userId = userContext.getCurrentUserId();
         PatternApplyResponseDTO.PatternApplyToggleDTO response =
-                patternApplyCommandService.toggleNotification(TEMP_USER_ID, patternApplyId);
+                patternApplyCommandService.toggleNotification(userId, patternApplyId);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 response,
                 SuccessStatus.SUCCESS_PATTERN_NOTIFICATION_TOGGLE.getCode(),
@@ -60,7 +61,8 @@ public class PatternApplyController {
     public ResponseEntity<?> updatePatternApply(
             @PathVariable Long patternApplyId,
             @RequestBody PatternApplyRequestDTO.PatternApplyUpdateDTO request) {
-                patternApplyCommandService.updatePatternApply(TEMP_USER_ID, patternApplyId, request);
+        Long userId = userContext.getCurrentUserId();
+                patternApplyCommandService.updatePatternApply(userId, patternApplyId, request);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 SuccessStatus.SUCCESS_PATTERN_APPLY_UPDATE.getCode(),
                 SuccessStatus.SUCCESS_PATTERN_APPLY_UPDATE.getMessage()
@@ -71,7 +73,8 @@ public class PatternApplyController {
     @Operation(summary = "패턴 적용 해제", description = "종목에 적용된 패턴을 해제합니다.")
     @DeleteMapping("/{patternApplyId}")
     public ResponseEntity<?> deletePatternApply(@PathVariable Long patternApplyId) {
-        patternApplyCommandService.deletePatternApply(TEMP_USER_ID, patternApplyId);
+        Long userId = userContext.getCurrentUserId();
+        patternApplyCommandService.deletePatternApply(userId, patternApplyId);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 SuccessStatus.SUCCESS_PATTERN_APPLY_UNLINK.getCode(),
                 SuccessStatus.SUCCESS_PATTERN_APPLY_UNLINK.getMessage()
@@ -84,8 +87,9 @@ public class PatternApplyController {
     public ResponseEntity<?> getPatternApplyDetailByStockId(
             @PathVariable Long stockId
     ) {
+        Long userId = userContext.getCurrentUserId();
         PatternApplyResponseDTO.PatternApplyDetailDTO response =
-                patternApplyQueryService.getPatternApplyDetail(TEMP_USER_ID, stockId);
+                patternApplyQueryService.getPatternApplyDetail(userId, stockId);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 response,
                 SuccessStatus.SUCCESS_PATTERN_APPLY_DETAIL.getCode(),

--- a/src/main/java/com/synergyx/trading/controller/PatternController.java
+++ b/src/main/java/com/synergyx/trading/controller/PatternController.java
@@ -1,5 +1,6 @@
 package com.synergyx.trading.controller;
 
+import com.synergyx.trading.config.context.UserContext;
 import com.synergyx.trading.dto.pattern.PatternRequestDTO;
 import com.synergyx.trading.dto.pattern.PatternResponseDTO;
 import com.synergyx.trading.service.patternService.PatternCommandService;
@@ -22,9 +23,7 @@ import java.util.List;
 @Tag(name = "패턴 API", description = "패턴 관련 API 입니다.")
 public class PatternController {
 
-    // 임시 userId
-    private static final Long TEMP_USER_ID = 1L;
-
+    private final UserContext userContext;
     private final PatternCommandService patternCommandService;
     private final PatternQueryService patternQueryService;
 
@@ -38,7 +37,8 @@ public class PatternController {
     )
     @PostMapping
     public ResponseEntity<?> createPattern(@RequestBody @Valid PatternRequestDTO dto) {
-        PatternResponseDTO.PatternDTO createdPattern = patternCommandService.createPattern(TEMP_USER_ID, dto);
+        Long userId = userContext.getCurrentUserId();
+        PatternResponseDTO.PatternDTO createdPattern = patternCommandService.createPattern(userId, dto);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 createdPattern,
@@ -51,7 +51,8 @@ public class PatternController {
     @Operation(summary = "패턴 목록 조회", description = "사용자의 종목 패턴 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<?> getPatternList() {
-    List<PatternResponseDTO.PatternDTO> list = patternQueryService.getPatternList(TEMP_USER_ID);
+        Long userId = userContext.getCurrentUserId();
+    List<PatternResponseDTO.PatternDTO> list = patternQueryService.getPatternList(userId);
     return ResponseEntity.ok(ApiResponse.onSuccess(list));
     }
 
@@ -61,7 +62,8 @@ public class PatternController {
     public ResponseEntity<?> getPatternDetail(
             @Parameter
             @PathVariable Long patternId) {
-        PatternResponseDTO.PatternDetailDTO dto = patternQueryService.getPatternDetail(TEMP_USER_ID, patternId);
+        Long userId = userContext.getCurrentUserId();
+        PatternResponseDTO.PatternDetailDTO dto = patternQueryService.getPatternDetail(userId, patternId);
         return ResponseEntity.ok(ApiResponse.onSuccess(dto));
     }
 
@@ -72,7 +74,8 @@ public class PatternController {
     public ResponseEntity<?> updatePattern(
             @PathVariable Long patternId,
             @RequestBody PatternRequestDTO dto) {
-        patternCommandService.updatePattern(TEMP_USER_ID, patternId, dto);
+        Long userId = userContext.getCurrentUserId();
+        patternCommandService.updatePattern(userId, patternId, dto);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 SuccessStatus.SUCCESS_PATTERN_UPDATE.getCode(),
                 SuccessStatus.SUCCESS_PATTERN_UPDATE.getMessage()
@@ -85,7 +88,8 @@ public class PatternController {
     public ResponseEntity<?> deletePattern(
             @Parameter
             @PathVariable Long patternId) {
-        patternCommandService.deletePattern(TEMP_USER_ID, patternId);
+        Long userId = userContext.getCurrentUserId();
+        patternCommandService.deletePattern(userId, patternId);
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 SuccessStatus.SUCCESS_PATTERN_DELETE.getCode(),
                 SuccessStatus.SUCCESS_PATTERN_DELETE.getMessage()

--- a/src/main/java/com/synergyx/trading/controller/StockController.java
+++ b/src/main/java/com/synergyx/trading/controller/StockController.java
@@ -2,6 +2,7 @@ package com.synergyx.trading.controller;
 
 import com.synergyx.trading.apiPayload.ApiResponse;
 import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
+import com.synergyx.trading.config.context.UserContext;
 import com.synergyx.trading.dto.stockDetail.RankedStockDTO;
 import com.synergyx.trading.dto.stockDetail.StockCandleResponseDTO;
 import com.synergyx.trading.dto.stockDetail.StockDetailResponseDTO;
@@ -27,9 +28,7 @@ import java.util.List;
 @Tag(name = "종목 상세 | 홈 API", description = "종목 상세, 홈 화면 관련 API 입니다.")
 public class StockController {
 
-    // 임시 userId
-    private static final Long TEMP_USER_ID = 1L;
-
+    private final UserContext userContext;
     private final StockSearchQueryService stockSearchQueryService;
     private final StockDetailQueryService stockDetailQueryService;
     private final StockCandleQueryService stockCandleQueryService;
@@ -38,7 +37,8 @@ public class StockController {
     @Operation(summary = "종목 상세 조회", description = "종목 상세 정보를 조회합니다.")
     @GetMapping("/{stockId}/detail")
     public ResponseEntity<?> getStockDetail(@PathVariable Long stockId) {
-        StockDetailResponseDTO dto = stockDetailQueryService.getStockDetail(stockId, TEMP_USER_ID);
+        Long userId = userContext.getCurrentUserId();
+        StockDetailResponseDTO dto = stockDetailQueryService.getStockDetail(stockId, userId);
         return ResponseEntity.ok(ApiResponse.onSuccess(dto));
     }
 

--- a/src/main/java/com/synergyx/trading/controller/UserController.java
+++ b/src/main/java/com/synergyx/trading/controller/UserController.java
@@ -2,6 +2,7 @@ package com.synergyx.trading.controller;
 
 import com.synergyx.trading.apiPayload.ApiResponse;
 import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
+import com.synergyx.trading.config.context.UserContext;
 import com.synergyx.trading.dto.user.UserRequestDTO;
 import com.synergyx.trading.service.userService.UserCommandService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,9 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "사용자 API", description = "사용자 관련 API 입니다.")
 public class UserController {
 
-    // 임시 userId
-    private static final Long TEMP_USER_ID = 1L;
-
+    private final UserContext userContext;
     private final UserCommandService userCommandService;
 
     @Operation(summary = "FCM 토큰 저장", description = "사용자의 FCM 토큰을 저장합니다.")
@@ -26,7 +25,8 @@ public class UserController {
     public ResponseEntity<?> updateFcmToken(
             @RequestBody UserRequestDTO.UpdateFcmTokenRequest request
     ) {
-        userCommandService.updateFcmToken(TEMP_USER_ID, request.getFcmToken());
+        Long userId = userContext.getCurrentUserId();
+        userCommandService.updateFcmToken(userId, request.getFcmToken());
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(
                         SuccessStatus.SUCCESS_FCM_TOKEN_UPDATED.getCode(),

--- a/src/main/java/com/synergyx/trading/dto/user/LoginRequestDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/user/LoginRequestDTO.java
@@ -1,0 +1,19 @@
+package com.synergyx.trading.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "로그인 요청 DTO")
+public record LoginRequestDTO(
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Schema(description = "사용자 이메일", example = "admin@email.com")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Schema(description = "사용자 비밀번호", example = "password!")
+        String password
+) {
+}

--- a/src/main/java/com/synergyx/trading/dto/user/LoginResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/user/LoginResponseDTO.java
@@ -1,0 +1,41 @@
+package com.synergyx.trading.dto.user;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "로그인 응답 DTO")
+public class LoginResponseDTO {
+
+    @Schema(description = "Access Token (JWT)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String accessToken;
+
+    @Schema(description = "Access Token의 만료 시간 (초 단위)", example = "3600")
+    private Long expiresIn;
+
+    @Schema(description = "로그인한 사용자 정보")
+    private LoginUserInfo userInfo;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class LoginUserInfo {
+
+        @JsonIgnore
+        private Long userId;
+
+        @Schema(description = "사용자 이름", example = "홍길동")
+        private String username;
+
+        @Schema(description = "신규 회원 여부", example = "true")
+        private Boolean isNewUser;
+    }
+}

--- a/src/main/java/com/synergyx/trading/dto/user/SignupRequestDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/user/SignupRequestDTO.java
@@ -1,0 +1,31 @@
+package com.synergyx.trading.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "회원가입 요청 DTO")
+public record SignupRequestDTO(
+
+        @NotBlank(message = "이름은 필수입니다.")
+        @Schema(description = "사용자 이름", example = "홍길동")
+        String name,
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Schema(description = "사용자 이메일", example = "example@email.com")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해야 합니다.")
+        @Schema(description = "사용자 비밀번호", example = "aw3afAe@")
+        String password,
+
+        @Schema(description = "마케팅 활용 동의 여부", example = "true")
+        boolean marketing,
+
+        @Schema(description = "이벤트 알림 수신 동의 여부", example = "false")
+        boolean event
+) {
+}

--- a/src/main/java/com/synergyx/trading/model/User.java
+++ b/src/main/java/com/synergyx/trading/model/User.java
@@ -23,6 +23,9 @@ public class User extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String username;
 
+    @Column(nullable = false, length = 255, unique = true)
+    private String email;
+
     @Column(length = 255)
     private String image;
 
@@ -35,10 +38,10 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private boolean pushEnabled;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String accessToken;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String refreshToken;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/synergyx/trading/repository/UserRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/UserRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long userId);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/synergyx/trading/service/userService/UserAuthService.java
+++ b/src/main/java/com/synergyx/trading/service/userService/UserAuthService.java
@@ -1,0 +1,16 @@
+package com.synergyx.trading.service.userService;
+
+import com.synergyx.trading.dto.user.LoginResponseDTO;
+import com.synergyx.trading.dto.user.SignupRequestDTO;
+
+public interface UserAuthService {
+
+    // 회원가입
+    void createUser(SignupRequestDTO request);
+
+    // 로그인
+    LoginResponseDTO login(String email, String password);
+
+    // 로그아웃
+    void logout(Long userId);
+}

--- a/src/main/java/com/synergyx/trading/service/userService/UserAuthServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/userService/UserAuthServiceImpl.java
@@ -47,7 +47,11 @@ public class UserAuthServiceImpl implements UserAuthService {
                 .agreeEvent(request.event())
                 .build();
 
-        userRepository.save(user);
+        try {
+            userRepository.save(user);
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            throw new GeneralException(ErrorStatus.AUTH_DUPLICATE_EMAIL);
+        }
         log.info("[SIGNUP] 신규 회원가입 완료 - email={}", user.getEmail());
     }
 

--- a/src/main/java/com/synergyx/trading/service/userService/UserAuthServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/userService/UserAuthServiceImpl.java
@@ -112,7 +112,7 @@ public class UserAuthServiceImpl implements UserAuthService {
      * SecurityContext에 인증 객체를 설정
      */
     private void setAuthentication(User user) {
-        Authentication authentication = new UserAuthentication(user.getId(), null, null);
+        Authentication authentication = new UserAuthentication(user.getId(), null, java.util.Collections.emptyList());
         SecurityContextHolder.getContext().setAuthentication(authentication);
         log.debug("[AUTH] SecurityContext에 인증 객체 설정 완료 - userId={}", user.getId());
     }

--- a/src/main/java/com/synergyx/trading/service/userService/UserAuthServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/userService/UserAuthServiceImpl.java
@@ -1,0 +1,119 @@
+package com.synergyx.trading.service.userService;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.config.security.UserAuthentication;
+import com.synergyx.trading.config.token.JwtTokenProvider;
+import com.synergyx.trading.dto.user.LoginResponseDTO;
+import com.synergyx.trading.dto.user.SignupRequestDTO;
+import com.synergyx.trading.model.User;
+import com.synergyx.trading.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserAuthServiceImpl implements UserAuthService {
+
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 회원가입
+     */
+    @Override
+    @Transactional
+    public void createUser(SignupRequestDTO request) {
+
+        // 이메일 중복 검사
+        if (userRepository.findByEmail(request.email()).isPresent()) {
+            throw new GeneralException(ErrorStatus.AUTH_DUPLICATE_EMAIL);
+        }
+
+        // 새 사용자 생성
+        User user = User.builder()
+                .username(request.name())
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .agreeMarketing(request.marketing())
+                .agreeEvent(request.event())
+                .build();
+
+        userRepository.save(user);
+        log.info("[SIGNUP] 신규 회원가입 완료 - email={}", user.getEmail());
+    }
+
+    /**
+     * 로그인
+     */
+    @Override
+    @Transactional
+    public LoginResponseDTO login(String email, String password) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.AUTH_INVALID_CREDENTIALS));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new GeneralException(ErrorStatus.AUTH_INVALID_CREDENTIALS);
+        }
+
+        // 인증 객체 등록
+        setAuthentication(user);
+
+        // 토큰 발급
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getId());
+        Long expiresIn = jwtTokenProvider.getAccessTokenExpirySeconds();
+
+        // DB에 AccessToken 저장
+        user.setAccessToken(accessToken);
+        userRepository.save(user);
+
+        log.info("[LOGIN] 토큰 발급 완료 - userId={}", user.getId());
+
+        return LoginResponseDTO.builder()
+                .accessToken(accessToken)
+                .expiresIn(expiresIn)
+                .userInfo(LoginResponseDTO.LoginUserInfo.builder()
+                        .userId(user.getId())
+                        .username(user.getUsername())
+                        .isNewUser(false)
+                        .build())
+                .build();
+    }
+
+    /**
+     * 로그아웃
+     */
+    @Override
+    @Transactional
+    public void logout(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._UNAUTHORIZED));
+
+        // DB에서 AccessToken 제거
+        user.setAccessToken(null);
+        userRepository.save(user);
+
+        // SecurityContext 비우기
+        SecurityContextHolder.clearContext();
+
+        log.info("[LOGOUT] 로그아웃 완료 - userId={}", user.getId());
+    }
+
+    /**
+     * SecurityContext에 인증 객체를 설정
+     */
+    private void setAuthentication(User user) {
+        Authentication authentication = new UserAuthentication(user.getId(), null, null);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.debug("[AUTH] SecurityContext에 인증 객체 설정 완료 - userId={}", user.getId());
+    }
+}

--- a/src/main/java/com/synergyx/trading/util/ErrorResponseUtil.java
+++ b/src/main/java/com/synergyx/trading/util/ErrorResponseUtil.java
@@ -1,0 +1,37 @@
+package com.synergyx.trading.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.synergyx.trading.apiPayload.ApiResponse;
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+/**
+ * 예외 발생 시 json 에러 응답을 생성합니다.
+ */
+public class ErrorResponseUtil {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * ErrorStatus를 기반으로 json 에러 응답을 생성합니다.
+     *
+     * @param response
+     * @param errorStatus
+     * @throws IOException
+     */
+    public static void writeErrorResponse(HttpServletResponse response, ErrorStatus errorStatus) throws IOException {
+        response.setStatus(errorStatus.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<Void> errorResponse = ApiResponse.onFailure(
+                errorStatus.getCode(),
+                errorStatus.getMessage(),
+                null
+        );
+
+        String json = mapper.writeValueAsString(errorResponse);
+        response.getWriter().write(json);
+    }
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
회원가입, 로그인, 로그아웃을 구현했습니다.

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #85

## ⏳ 작업 내용
- 회원가입, 로그인, 로그아웃 구현 jwt 적용
- 기존 TEMP_USERID 를 실제 userid로 변경함
- access token 만 사용 (refresh 사용 x)
  - 24시간 유효함

## 📸 스크린샷
- 
<img width="1474" height="233" alt="image" src="https://github.com/user-attachments/assets/64d885bb-4073-4b5b-9c88-bab1ca22f1c2" />

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 머지하면 프론트에서 로그인 연동 구현 이전까지 접근 불가능 -> 논의 후 머지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 회원가입/로그인/로그아웃 REST API 추가 및 로그인 시 액세스 토큰과 만료 정보 제공
  - JWT 토큰 생성·검증 및 인증 필터 도입으로 토큰 기반 인증 적용
  - 로그인/회원가입 성공·오류에 대한 표준화된 상태 메시지(한국어) 추가

- **Bug Fixes / Improvements**
  - 인증 실패(401) 및 권한 거부(403)에 대한 일관된 응답 처리 제공
  - 비밀번호 암호화 및 토큰 검증 강화

- **Refactor**
  - 컨트롤러 전반에서 임시 사용자 ID 제거, 인증된 사용자 컨텍스트로 대체
  - 사용자 이메일 고유 제약 추가 및 로그인/회원가입 DTO·응답 구조 정비
<!-- end of auto-generated comment: release notes by coderabbit.ai -->