### PR TITLE
Feat/#91 auth withdraw profile

### DIFF
--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
@@ -50,9 +50,10 @@ public enum SuccessStatus implements BaseCode {
     SUCCESS_DELETE_EMOTION_DIARY(HttpStatus.OK, "DIARY2002", "감정 투자 일기가 삭제되었습니다."),
 
     // 인증
-    AUTH_LOGIN_SUCCESS(HttpStatus.OK, "AUTH200", "로그인 성공"),
-    AUTH_SIGNUP_SUCCESS(HttpStatus.OK, "AUTH201", "회원가입 성공"),
-    AUTH_LOGOUT_SUCCESS(HttpStatus.OK, "AUTH202", "로그아웃 성공")
+    AUTH_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2000", "로그인 성공"),
+    AUTH_SIGNUP_SUCCESS(HttpStatus.OK, "AUTH2001", "회원가입 성공"),
+    AUTH_LOGOUT_SUCCESS(HttpStatus.OK, "AUTH2002", "로그아웃 성공"),
+    AUTH_WITHDRAW_SUCCESS(HttpStatus.OK, "AUTH2003", "회원탈퇴 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
@@ -53,7 +53,11 @@ public enum SuccessStatus implements BaseCode {
     AUTH_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2000", "로그인 성공"),
     AUTH_SIGNUP_SUCCESS(HttpStatus.OK, "AUTH2001", "회원가입 성공"),
     AUTH_LOGOUT_SUCCESS(HttpStatus.OK, "AUTH2002", "로그아웃 성공"),
-    AUTH_WITHDRAW_SUCCESS(HttpStatus.OK, "AUTH2003", "회원탈퇴 성공")
+    AUTH_WITHDRAW_SUCCESS(HttpStatus.OK, "AUTH2003", "회원탈퇴 성공"),
+
+    // User
+    USER_PROFILE_SUCCESS(HttpStatus.OK, "USER2000", "프로필 조회 성공"),
+    USER_PROFILE_UPDATE_SUCCESS(HttpStatus.OK, "USER2001", "프로필 수정 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/synergyx/trading/controller/AuthController.java
+++ b/src/main/java/com/synergyx/trading/controller/AuthController.java
@@ -74,4 +74,19 @@ public class AuthController {
                 SuccessStatus.AUTH_LOGOUT_SUCCESS.getMessage()
         ));
     }
+
+    @PostMapping("/withdraw")
+    @Operation(summary = "회원 탈퇴",
+            description = "현재 로그인된 사용자를 탈퇴 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> withdraw(
+    ) {
+        Long userId = userContext.getCurrentUserId();
+
+        userAuthService.withdrawUser(userId);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                SuccessStatus.AUTH_WITHDRAW_SUCCESS.getCode(),
+                SuccessStatus.AUTH_WITHDRAW_SUCCESS.getMessage()
+        ));
+    }
 }

--- a/src/main/java/com/synergyx/trading/controller/UserController.java
+++ b/src/main/java/com/synergyx/trading/controller/UserController.java
@@ -3,10 +3,13 @@ package com.synergyx.trading.controller;
 import com.synergyx.trading.apiPayload.ApiResponse;
 import com.synergyx.trading.apiPayload.code.status.SuccessStatus;
 import com.synergyx.trading.config.context.UserContext;
+import com.synergyx.trading.dto.user.ProfileUpdateRequestDTO;
 import com.synergyx.trading.dto.user.UserRequestDTO;
 import com.synergyx.trading.service.userService.UserCommandService;
+import com.synergyx.trading.service.userService.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +22,7 @@ public class UserController {
 
     private final UserContext userContext;
     private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
 
     @Operation(summary = "FCM 토큰 저장", description = "사용자의 FCM 토큰을 저장합니다.")
     @PatchMapping("/fcm-token")
@@ -33,5 +37,37 @@ public class UserController {
                         SuccessStatus.SUCCESS_FCM_TOKEN_UPDATED.getMessage()
                 )
         );
+    }
+
+    @GetMapping("/profile")
+    @Operation(summary = "프로필 조회",
+            description = "사용자의 프로필을 조회합니다.")
+    public ResponseEntity<ApiResponse<String>> getProfile(
+    ) {
+        Long userId = userContext.getCurrentUserId();
+
+        String name = userQueryService.getProfileName(userId);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                name,
+                SuccessStatus.USER_PROFILE_SUCCESS.getCode(),
+                SuccessStatus.USER_PROFILE_SUCCESS.getMessage()
+        ));
+    }
+
+    @PatchMapping("/profile")
+    @Operation(summary = "프로필 수정",
+            description = "사용자의 프로필을 수정합니다.")
+    public ResponseEntity<ApiResponse<Void>> updateProfile(
+            @Valid @RequestBody ProfileUpdateRequestDTO requestDTO
+    ) {
+        Long userId = userContext.getCurrentUserId();
+
+        userCommandService.updateProfile(userId, requestDTO);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                SuccessStatus.USER_PROFILE_UPDATE_SUCCESS.getCode(),
+                SuccessStatus.USER_PROFILE_UPDATE_SUCCESS.getMessage()
+        ));
     }
 }

--- a/src/main/java/com/synergyx/trading/dto/user/ProfileUpdateRequestDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/user/ProfileUpdateRequestDTO.java
@@ -1,0 +1,13 @@
+package com.synergyx.trading.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "프로필 수정 요청 DTO")
+public record ProfileUpdateRequestDTO(
+
+        @NotBlank(message = "이름은 필수입니다.")
+        @Schema(description = "새로운 이름", example = "아무개")
+        String name
+) {
+}

--- a/src/main/java/com/synergyx/trading/model/User.java
+++ b/src/main/java/com/synergyx/trading/model/User.java
@@ -46,4 +46,7 @@ public class User extends BaseEntity {
 
     @Column(columnDefinition = "TEXT")
     private String fcmToken;
+
+    @Column(nullable = false)
+    private boolean deleted;
 }

--- a/src/main/java/com/synergyx/trading/service/userService/UserAuthService.java
+++ b/src/main/java/com/synergyx/trading/service/userService/UserAuthService.java
@@ -13,4 +13,7 @@ public interface UserAuthService {
 
     // 로그아웃
     void logout(Long userId);
+
+    // 회원탈퇴
+    void withdrawUser(Long userId);
 }

--- a/src/main/java/com/synergyx/trading/service/userService/UserAuthServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/userService/UserAuthServiceImpl.java
@@ -118,18 +118,19 @@ public class UserAuthServiceImpl implements UserAuthService {
     @Override
     @Transactional
     public void withdrawUser(Long userId) {
-        userRepository.findById(userId).ifPresent(user -> {
-            user.setEmail("deleted_" + user.getId() + "@example.com");
-            user.setPassword("");
-            user.setAccessToken(null);
-            user.setRefreshToken(null);
-            user.setFcmToken(null);
-            user.setUsername("탈퇴회원");
-            user.setAgreeMarketing(false);
-            user.setAgreeEvent(false);
-            user.setPushEnabled(false);
-            user.setDeleted(true); // soft delete flag
-        });
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        user.setEmail("deleted_" + user.getId() + "@example.com");
+        user.setPassword("");
+        user.setAccessToken(null);
+        user.setRefreshToken(null);
+        user.setFcmToken(null);
+        user.setUsername("탈퇴회원");
+        user.setAgreeMarketing(false);
+        user.setAgreeEvent(false);
+        user.setPushEnabled(false);
+        user.setDeleted(true); // soft delete flag
     }
 
     /**

--- a/src/main/java/com/synergyx/trading/service/userService/UserAuthServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/userService/UserAuthServiceImpl.java
@@ -113,6 +113,26 @@ public class UserAuthServiceImpl implements UserAuthService {
     }
 
     /**
+     * 회원 탈퇴 (soft delete)
+     */
+    @Override
+    @Transactional
+    public void withdrawUser(Long userId) {
+        userRepository.findById(userId).ifPresent(user -> {
+            user.setEmail("deleted_" + user.getId() + "@example.com");
+            user.setPassword("");
+            user.setAccessToken(null);
+            user.setRefreshToken(null);
+            user.setFcmToken(null);
+            user.setUsername("탈퇴회원");
+            user.setAgreeMarketing(false);
+            user.setAgreeEvent(false);
+            user.setPushEnabled(false);
+            user.setDeleted(true); // soft delete flag
+        });
+    }
+
+    /**
      * SecurityContext에 인증 객체를 설정
      */
     private void setAuthentication(User user) {

--- a/src/main/java/com/synergyx/trading/service/userService/UserCommandService.java
+++ b/src/main/java/com/synergyx/trading/service/userService/UserCommandService.java
@@ -1,11 +1,22 @@
 package com.synergyx.trading.service.userService;
 
+import com.synergyx.trading.dto.user.ProfileUpdateRequestDTO;
+
 public interface UserCommandService {
 
     /**
      * FCM 토큰을 업데이트합니다.
+     *
      * @param userId   사용자 ID
      * @param fcmToken 새로운 FCM 토큰
      */
     void updateFcmToken(Long userId, String fcmToken);
+
+    /**
+     * 사용자 정보를 업데이트 합니다.
+     *
+     * @param userId
+     * @param requestDTO 수정 요청 dto
+     */
+    void updateProfile(Long userId, ProfileUpdateRequestDTO requestDTO);
 }

--- a/src/main/java/com/synergyx/trading/service/userService/UserCommandServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/userService/UserCommandServiceImpl.java
@@ -2,6 +2,7 @@ package com.synergyx.trading.service.userService;
 
 import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
 import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.dto.user.ProfileUpdateRequestDTO;
 import com.synergyx.trading.model.User;
 import com.synergyx.trading.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,18 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         user.setFcmToken(fcmToken);
+        userRepository.save(user);
+    }
+
+    @Override
+    @Transactional
+    public void updateProfile(Long userId, ProfileUpdateRequestDTO requestDTO) {
+        String newName = requestDTO.name();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        user.setUsername(newName);
         userRepository.save(user);
     }
 }

--- a/src/main/java/com/synergyx/trading/service/userService/UserQueryService.java
+++ b/src/main/java/com/synergyx/trading/service/userService/UserQueryService.java
@@ -1,0 +1,6 @@
+package com.synergyx.trading.service.userService;
+
+public interface UserQueryService {
+
+    String getProfileName(Long userId);
+}

--- a/src/main/java/com/synergyx/trading/service/userService/UserQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/userService/UserQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package com.synergyx.trading.service.userService;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.model.User;
+import com.synergyx.trading.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryServiceImpl implements UserQueryService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public String getProfileName(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        return user.getUsername();
+    }
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
회원 탈퇴, 프로필 조회/수정 api 구현

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #91

## ⏳ 작업 내용
- 회원 탈퇴 (soft delete)
  - deleted 컬럼 추가 (true: 탈퇴)
  - 백테스트 통계 등 기록 정보를 남겨놓기 위해 이메일 등 마스킹 처리
    - password -> 공백
    - 이메일 -> deleted_{userId}@example.com
    - 동의여부 -> false
    - username -> 탈퇴회원
<img width="1143" height="131" alt="스크린샷 2025-09-11 18 47 17" src="https://github.com/user-attachments/assets/b746bbb9-c68b-4b0f-9e24-6a2f81785e18" />

- 프로필 조회
  - 현재는 이름만 반환
  
- 프로필 수정
  - 이름만 요청

## 📸 스크린샷
<img width="812" height="755" alt="스크린샷 2025-09-11 19 35 12" src="https://github.com/user-attachments/assets/07d4830e-7f03-41a9-a938-69af7a8c981c" />
<img width="791" height="212" alt="스크린샷 2025-09-11 19 35 27" src="https://github.com/user-attachments/assets/22515335-e4e8-4e87-ab06-5bfd6206eaf3" />


## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 계정 탈퇴: 로그인 상태에서 계정 탈퇴를 요청할 수 있습니다. 탈퇴 시 개인정보가 안전하게 비식별 처리되며 알림 수신이 해제됩니다.
  * 프로필 조회/수정: 내 프로필 이름을 확인하고 변경할 수 있는 엔드포인트가 추가되었습니다. 이름은 비어 있을 수 없습니다.
  * 응답 개선: 인증/사용자 관련 성공 응답 코드가 일관되게 정비되어 클라이언트 처리 경험이 향상됩니다. 모든 작업 결과는 표준 성공 응답으로 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->