### PR TITLE
Feat/#93 backtest ranking

### DIFF
--- a/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/synergyx/trading/apiPayload/code/status/SuccessStatus.java
@@ -33,6 +33,7 @@ public enum SuccessStatus implements BaseCode {
 
     // 백테스팅
     SUCCESS_BACKTEST_EXECUTE(HttpStatus.OK, "BACKTEST200", "백테스트가 실행되었습니다."),
+    SUCCESS_RANKING(HttpStatus.OK, "RANK200", "백테스팅 랭킹 조회 성공"),
 
     // 종목 상세
     SUCCESS_CHART_DATA(HttpStatus.OK, "CANDLE200", "차트 데이터 조회 성공."),

--- a/src/main/java/com/synergyx/trading/controller/BacktestController.java
+++ b/src/main/java/com/synergyx/trading/controller/BacktestController.java
@@ -8,6 +8,7 @@ import com.synergyx.trading.config.context.UserContext;
 import com.synergyx.trading.dto.backtest.BacktestRequestDTO;
 import com.synergyx.trading.dto.backtest.BacktestResponseDTO;
 import com.synergyx.trading.service.backtestService.BacktestService;
+import com.synergyx.trading.service.backtestService.ranking.BacktestRankingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +26,7 @@ public class BacktestController {
 
     private final UserContext userContext;
     private final BacktestService backtestService;
+    private final BacktestRankingService backtestRankingService;
 
     // 백테스트 실행
     @Operation(summary = "백테스팅 실행", description = "백테스팅을 실행합니다.")
@@ -97,6 +100,20 @@ public class BacktestController {
                 candles,
                 SuccessStatus.SUCCESS_CHART_DATA.getCode(),
                 SuccessStatus.SUCCESS_CHART_DATA.getMessage()
+        ));
+    }
+
+    // 백테스팅 랭킹 조회
+    @Operation(summary = "백테스팅 랭킹 조회", description = "최대 수익률을 기준으로 백테스팅 랭킹을 조회합니다. (조건: 점 3개 이상의 패턴으로 실행된 백테스팅)")
+    @GetMapping("/rankings")
+    public ResponseEntity<?> getRankings(
+            @RequestParam(required = false, defaultValue = "100") int limit) {
+        List<?> rankings = backtestRankingService.getRanking(limit);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                rankings,
+                SuccessStatus.SUCCESS_RANKING.getCode(),
+                SuccessStatus.SUCCESS_RANKING.getMessage()
         ));
     }
 }

--- a/src/main/java/com/synergyx/trading/dto/backtest/BacktestRankingDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/backtest/BacktestRankingDTO.java
@@ -1,0 +1,34 @@
+package com.synergyx.trading.dto.backtest;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+// 백테스팅 랭킹 조회
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BacktestRankingDTO implements Rankable {
+    private Integer rank; // 랭킹 순위
+    private Long userId; // 사용자 아이디
+    private String username; // 사용자 이름
+    private String image; // 사용자 이미지
+    private Double winRate; // 승률
+    private Double averageReturn; // 평균 수익률
+    private Double maxReturn; // 최대 수익률
+    private LocalDate maxReturnDate; // 최대 수익률 발생일
+    private Long backtestId; // 백테스팅 아이디
+
+    public BacktestRankingDTO(Long userId, String username, String image, Double winRate, Double averageReturn, Double maxReturn, LocalDate maxReturnDate, Long backtestId) {
+        this.userId = userId;
+        this.username = username;
+        this.image = image;
+        this.winRate = winRate;
+        this.averageReturn = averageReturn;
+        this.maxReturn = maxReturn;
+        this.maxReturnDate = maxReturnDate;
+        this.backtestId = backtestId;
+    }
+}

--- a/src/main/java/com/synergyx/trading/dto/backtest/Rankable.java
+++ b/src/main/java/com/synergyx/trading/dto/backtest/Rankable.java
@@ -1,0 +1,6 @@
+package com.synergyx.trading.dto.backtest;
+
+// 백테스팅 랭킹에 쓰이는 순위 부여용 인터페이스
+public interface Rankable {
+    void setRank(Integer rank);
+}

--- a/src/main/java/com/synergyx/trading/repository/BacktestRankingRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/BacktestRankingRepository.java
@@ -1,0 +1,47 @@
+package com.synergyx.trading.repository;
+
+import com.synergyx.trading.dto.backtest.BacktestRankingDTO;
+import com.synergyx.trading.model.Backtest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface BacktestRankingRepository extends JpaRepository<Backtest, Long> {
+
+    // 최대 수익률 월간 랭킹 조회
+    @Query("""
+
+            SELECT new com.synergyx.trading.dto.backtest.BacktestRankingDTO(
+        b.user.id,
+        b.user.username,
+        b.user.image,
+        b.winRate,
+        b.averageReturn,
+        b.maxReturn,
+        b.maxReturnDate,
+        b.id
+    )
+    FROM Backtest b
+    WHERE b.executedAt BETWEEN :startOfMonth AND :endOfMonth
+      AND b.user.username <> '탈퇴회원'
+      AND b.maxReturn = (
+          SELECT MAX(b2.maxReturn)
+          FROM Backtest b2
+          WHERE b2.user.id = b.user.id
+            AND b2.executedAt BETWEEN :startOfMonth AND :endOfMonth
+      )
+    ORDER BY b.maxReturn DESC, b.winRate DESC
+    """)
+    List<BacktestRankingDTO> findMonthlyUserMaxReturnRankings(
+            @Param("startOfMonth") LocalDate startOfMonth,
+            @Param("endOfMonth") LocalDate endOfMonth,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/synergyx/trading/service/backtestService/ranking/BacktestRankingService.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/ranking/BacktestRankingService.java
@@ -12,7 +12,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,11 +41,23 @@ public class BacktestRankingService {
         // Repository 호출
         List<BacktestRankingDTO> rankings = backtestRankingRepository.findMonthlyUserMaxReturnRankings(startOfMonth, endOfMonth, PageRequest.of(0, limit));
 
+        // 백테스트 ID 목록 추출
+        List<Long> backtestIds = rankings.stream()
+                .map(BacktestRankingDTO::getBacktestId)
+                .toList();
+
+        // 일괄 조회
+        Map<Long, Backtest> backtestMap = backtestRepository.findAllById(backtestIds)
+                .stream()
+                .collect(Collectors.toMap(Backtest::getId, Function.identity()));
+
         // 점 개수 3개 이상 조건 필터링
         rankings = rankings.stream()
                 .filter(r -> {
-                    Backtest backtest = backtestRepository.findById(r.getBacktestId())
-                            .orElseThrow(() -> new GeneralException(ErrorStatus.BACKTEST_NOT_FOUND));
+                    Backtest backtest = backtestMap.get(r.getBacktestId());
+                    if (backtest == null) {
+                        throw new GeneralException(ErrorStatus.BACKTEST_NOT_FOUND);
+                    }
                     return backtest.getPattern().getPoints().size() >= 3;
                 })
                 .toList();

--- a/src/main/java/com/synergyx/trading/service/backtestService/ranking/BacktestRankingService.java
+++ b/src/main/java/com/synergyx/trading/service/backtestService/ranking/BacktestRankingService.java
@@ -1,0 +1,55 @@
+package com.synergyx.trading.service.backtestService.ranking;
+
+import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
+import com.synergyx.trading.apiPayload.exception.GeneralException;
+import com.synergyx.trading.dto.backtest.BacktestRankingDTO;
+import com.synergyx.trading.dto.backtest.Rankable;
+import com.synergyx.trading.model.Backtest;
+import com.synergyx.trading.repository.BacktestRankingRepository;
+import com.synergyx.trading.repository.BacktestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+@RequiredArgsConstructor
+public class BacktestRankingService {
+
+    private final BacktestRepository backtestRepository;
+    private final BacktestRankingRepository backtestRankingRepository;
+
+    // 랭킹 순위 부여용 메서드
+    private <T extends Rankable> void assignRanks(List<T> results) {
+        AtomicInteger rank = new AtomicInteger(1);
+        results.forEach(r -> r.setRank(rank.getAndIncrement()));
+    }
+
+    // 랭킹 조회 (최대 수익률, 월간 기준)
+    public List<BacktestRankingDTO> getRanking(int limit) {
+
+        // 월간 기간 계산 (1일 ~ 31일)
+        LocalDate now = LocalDate.now();
+        LocalDate startOfMonth = now.withDayOfMonth(1);
+        LocalDate endOfMonth = now.withDayOfMonth(now.lengthOfMonth());
+
+        // Repository 호출
+        List<BacktestRankingDTO> rankings = backtestRankingRepository.findMonthlyUserMaxReturnRankings(startOfMonth, endOfMonth, PageRequest.of(0, limit));
+
+        // 점 개수 3개 이상 조건 필터링
+        rankings = rankings.stream()
+                .filter(r -> {
+                    Backtest backtest = backtestRepository.findById(r.getBacktestId())
+                            .orElseThrow(() -> new GeneralException(ErrorStatus.BACKTEST_NOT_FOUND));
+                    return backtest.getPattern().getPoints().size() >= 3;
+                })
+                .toList();
+
+        // 순위 부여
+        assignRanks(rankings);
+
+        return rankings;
+    }
+}


### PR DESCRIPTION
## 🚀 개요
백테스팅 랭킹 구현

## 📌 관련 이슈
- Closes #93 

## ⏳ 작업 내용
- 백테스팅 랭킹 구현 
- 최고 수익률 기준
- 월간 랭킹

## 📸 스크린샷
<img width="397" height="525" alt="image" src="https://github.com/user-attachments/assets/f0675c24-7143-4524-bdba-e7da6fa365ab" />

## 📝 참고 사항
- 유의미함을 위해 점 3개 이상으로 이루어진 패턴에 한해서 랭킹에 반영됩니다.
- 최고 수익률이 같을 경우, 승률이 높은 유저의 순위가 더 높음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 백테스팅 월간 랭킹 조회 기능을 추가했습니다. 상위 사용자들의 승률, 평균/최대 수익률, 최대 수익일 등 지표와 랭크를 함께 확인할 수 있습니다.
  - 기본 100개까지 조회되며 요청 파라미터로 조회 개수를 조정할 수 있습니다.
  - 월간 기준으로 집계되며 부적합 데이터(비활성 사용자, 패턴 포인트 부족 등)는 제외되어 신뢰도를 높였습니다.
  - 랭킹 전용 성공 상태 코드/메시지가 추가되어 응답이 보다 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->