### PR TITLE
[REFACTOR] 관심종목 엔티티에 orm, fetch join 적용 및 필드 추가 #98

### DIFF
--- a/src/main/java/com/synergyx/trading/dto/InterestStock/InterestStockResponseDTO.java
+++ b/src/main/java/com/synergyx/trading/dto/InterestStock/InterestStockResponseDTO.java
@@ -10,12 +10,16 @@ public class InterestStockResponseDTO {
     private Long stockId;
     private String stockName;
     private String stockSymbol;
+    private String price;
+    private String changeRate;
     private String imageUrl;
 
-    public InterestStockResponseDTO(Long stockId, String stockName, String stockSymbol, String imageUrl) {
+    public InterestStockResponseDTO(Long stockId, String stockName, String stockSymbol, String price, String changeRate, String imageUrl) {
         this.stockId = stockId;
         this.stockName = stockName;
         this.stockSymbol = stockSymbol;
+        this.price = price;
+        this.changeRate = changeRate;
         this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/synergyx/trading/model/RecentViewStock.java
+++ b/src/main/java/com/synergyx/trading/model/RecentViewStock.java
@@ -19,11 +19,13 @@ public class RecentViewStock {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-    @Column(name = "stock_id", nullable = false)
-    private Long stockId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
 
     @Column(name = "viewed_at", nullable = false)
     private LocalDateTime viewedAt;

--- a/src/main/java/com/synergyx/trading/model/Stock.java
+++ b/src/main/java/com/synergyx/trading/model/Stock.java
@@ -24,4 +24,7 @@ public class Stock extends BaseEntity {
 
     @Column(name = "image_url", nullable = true, length = 255)
     private String imageUrl;
+
+    @OneToOne(mappedBy = "stock")
+    private StockDetail stockDetail;
 }

--- a/src/main/java/com/synergyx/trading/repository/InterestStockRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/InterestStockRepository.java
@@ -1,6 +1,7 @@
 package com.synergyx.trading.repository;
 
 import com.synergyx.trading.model.InterestStock;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,9 +12,8 @@ import java.util.Optional;
 public interface InterestStockRepository extends JpaRepository<InterestStock, Long> {
     Optional<InterestStock> findByUserIdAndStockId(Long userId, Long stockId);
 
+    @EntityGraph(attributePaths = {"stock", "stock.stockDetail"})
     List<InterestStock> findAllByUserId(Long userId);
-
-    void deleteByUserIdAndStockId(Long userId, Long stockId);
 
     boolean existsByUserIdAndStockId(Long userId, Long stockId);
 }

--- a/src/main/java/com/synergyx/trading/repository/RecentViewStockRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/RecentViewStockRepository.java
@@ -2,6 +2,7 @@ package com.synergyx.trading.repository;
 
 import com.synergyx.trading.dto.InterestStock.InterestStockResponseDTO;
 import com.synergyx.trading.model.RecentViewStock;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,17 +12,8 @@ import java.util.List;
 
 public interface RecentViewStockRepository extends JpaRepository<RecentViewStock, Long> {
 
-    @Query("""
-                SELECT new com.synergyx.trading.dto.InterestStock.InterestStockResponseDTO(
-                    s.id, s.name, s.symbol, s.imageUrl
-                )
-                FROM RecentViewStock r
-                JOIN Stock s ON r.stockId = s.id
-                WHERE r.userId = :userId
-                ORDER BY r.viewedAt DESC
-            """)
-    List<InterestStockResponseDTO> findRecentStocksWithInfo(@Param("userId") Long userId);
-
+    @EntityGraph(attributePaths = {"stock", "stock.stockDetail"})
+    List<RecentViewStock> findByUserIdOrderByViewedAtDesc(Long userId);
 
     // 중복 제거 (stockId 1개 삭제)
     void deleteByUserIdAndStockId(Long userId, Long stockId);
@@ -29,16 +21,18 @@ public interface RecentViewStockRepository extends JpaRepository<RecentViewStock
     // 20개 초과된 데이터 삭제
     @Modifying
     @Query(value = """
-                DELETE FROM recent_view_stock
-                WHERE user_id = :userId
-                  AND id NOT IN (
-                      SELECT id FROM (
-                          SELECT id FROM recent_view_stock
-                          WHERE user_id = :userId
-                          ORDER BY viewed_at DESC
-                          LIMIT 20
-                      ) AS tmp
-                  )
+                DELETE r FROM recent_view_stock r
+                WHERE r.user_id = :userId
+                AND r.id NOT IN (
+                    SELECT id
+                    FROM (
+                        SELECT id
+                        FROM recent_view_stock
+                        WHERE user_id = :userId
+                        ORDER BY viewed_at DESC
+                        LIMIT 20
+                    ) tmp
+                )
             """, nativeQuery = true)
     void deleteOverLimit(Long userId);
 }

--- a/src/main/java/com/synergyx/trading/service/InterestStockService/InterestStockCommandServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/InterestStockService/InterestStockCommandServiceImpl.java
@@ -79,13 +79,22 @@ public class InterestStockCommandServiceImpl implements InterestStockCommandServ
     @Override
     @Transactional(propagation = REQUIRES_NEW)
     public void addRecentView(Long userId, Long stockId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 종목 조회
+        Stock stock = stockRepository.findById(stockId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.STOCK_NOT_FOUND));
+
         // 중복 제거
         recentViewStockRepository.deleteByUserIdAndStockId(userId, stockId);
 
+        // 기록 저장
         recentViewStockRepository.save(
                 RecentViewStock.builder()
-                        .userId(userId)
-                        .stockId(stockId)
+                        .user(user)
+                        .stock(stock)
                         .viewedAt(LocalDateTime.now())
                         .build()
         );

--- a/src/main/java/com/synergyx/trading/service/InterestStockService/InterestStockQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/InterestStockService/InterestStockQueryServiceImpl.java
@@ -3,6 +3,8 @@ package com.synergyx.trading.service.InterestStockService;
 import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
 import com.synergyx.trading.apiPayload.exception.GeneralException;
 import com.synergyx.trading.dto.InterestStock.InterestStockResponseDTO;
+import com.synergyx.trading.model.Stock;
+import com.synergyx.trading.model.StockDetail;
 import com.synergyx.trading.model.User;
 import com.synergyx.trading.repository.InterestStockRepository;
 import com.synergyx.trading.repository.RecentViewStockRepository;
@@ -12,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static com.synergyx.trading.util.ParsingUtil.toFormattedNumber;
 
 @Service
 @RequiredArgsConstructor
@@ -34,13 +38,20 @@ public class InterestStockQueryServiceImpl implements InterestStockQueryService 
         User user = getValidUser(userId);
 
         return interestStockRepository.findAllByUserId(userId).stream()
-                .map(i -> InterestStockResponseDTO.builder()
-                        .stockId(i.getStock().getId())
-                        .stockName(i.getStock().getName())
-                        .stockSymbol(i.getStock().getSymbol())
-                        .imageUrl(i.getStock().getImageUrl())
-                        .build()
-                ).toList();
+                .map(i -> {
+                    Stock stock = i.getStock();
+                    StockDetail detail = stock.getStockDetail(); // entity graph로 fetch
+
+                    return InterestStockResponseDTO.builder()
+                            .stockId(i.getStock().getId())
+                            .stockName(i.getStock().getName())
+                            .stockSymbol(i.getStock().getSymbol())
+                            .price(detail != null ? toFormattedNumber(detail.getPrice()) : null)
+                            .changeRate(detail != null ? (detail.getChangeRate() + "%") : null)
+                            .imageUrl(i.getStock().getImageUrl())
+                            .build();
+                })
+                .toList();
     }
 
     /**
@@ -54,7 +65,21 @@ public class InterestStockQueryServiceImpl implements InterestStockQueryService 
     public List<InterestStockResponseDTO> getRecentViewStocks(Long userId) {
         User user = getValidUser(userId);
 
-        return recentViewStockRepository.findRecentStocksWithInfo(userId);
+        return recentViewStockRepository.findByUserIdOrderByViewedAtDesc(userId).stream()
+                .map(r -> {
+                    var stock = r.getStock();
+                    var detail = stock.getStockDetail();
+
+                    return InterestStockResponseDTO.builder()
+                            .stockId(stock.getId())
+                            .stockName(stock.getName())
+                            .stockSymbol(stock.getSymbol())
+                            .price(detail != null ? toFormattedNumber(detail.getPrice()) : null)
+                            .changeRate(detail != null ? (detail.getChangeRate() + "%") : null)
+                            .imageUrl(stock.getImageUrl())
+                            .build();
+                })
+                .toList();
     }
 
     /**


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->


## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #98

## ⏳ 작업 내용
- 관심종목, 최근 조회 종목 응답에 등락률, 현재가 필드 추가
- RecentViewStock, InterestStock 엔티티에 orm, fetch join 적용 (entity graph 사용)

## 📸 스크린샷
- 
<img width="787" height="569" alt="image" src="https://github.com/user-attachments/assets/fcf9face-136d-4d33-8c5b-d1edb2aaf8b5" />

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 관심종목과 최근 본 종목에 실시간 가격과 등락률(%) 표시를 추가했습니다.
  * 가격은 읽기 쉬운 형식으로 표기되며, 등락률은 % 기호와 함께 제공됩니다.

* 변경 사항
  * 최근 본 종목 목록이 최신순으로 최대 20개까지 표시됩니다.
  * 관심종목/최근 본 종목 카드에 종목 이미지와 기본 정보가 함께 더 풍부하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->