### PR TITLE
[REFACTOR] 관리자 계정 백테스팅 랭킹 반영 제외 #93

### DIFF
--- a/src/main/java/com/synergyx/trading/repository/BacktestRankingRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/BacktestRankingRepository.java
@@ -30,7 +30,7 @@ public interface BacktestRankingRepository extends JpaRepository<Backtest, Long>
     )
     FROM Backtest b
     WHERE b.executedAt BETWEEN :startOfMonth AND :endOfMonth
-      AND b.user.username <> '탈퇴회원'
+      AND b.user.username NOT IN ('탈퇴회원', 'admin')
       AND b.maxReturn = (
           SELECT MAX(b2.maxReturn)
           FROM Backtest b2


### PR DESCRIPTION
## 🚀 개요
관리자 계정 백테스팅 랭킹 반영 제외

## 📌 관련 이슈
- Closes #93

## ⏳ 작업 내용
- Repository 쿼리 수정

## 📸 스크린샷
<img width="496" height="552" alt="image" src="https://github.com/user-attachments/assets/aba41b32-f73b-46bd-b716-a85054545af4" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 월간 백테스트 수익률 순위에서 관리자 계정과 탈퇴한 계정이 제외되도록 필터를 보완했습니다. 이를 통해 실제 사용자 중심의 순위가 더 정확하고 공정하게 반영됩니다. 계산 방식과 정렬 기준은 그대로 유지되며, 순위 목록에 불필요한 계정이 더 이상 포함되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->