### PR TITLE
Refactor/#97 ai top 20 add actual data

### DIFF
--- a/src/main/java/com/synergyx/trading/model/StockDetail.java
+++ b/src/main/java/com/synergyx/trading/model/StockDetail.java
@@ -37,4 +37,10 @@ public class StockDetail extends BaseEntity {
     @Version
     @Column(name = "version")
     private Long version; // 동시성 제어를 위해 추가
+
+    @Column(name = "ai_avg_increase", columnDefinition = "double default 0")
+    private Double aiAvgIncrease;
+
+    @Column(name = "ai_rank")
+    private Integer aiRank;
 }

--- a/src/main/java/com/synergyx/trading/repository/StockDetailRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/StockDetailRepository.java
@@ -4,6 +4,7 @@ import com.synergyx.trading.model.StockDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +12,6 @@ public interface StockDetailRepository extends JpaRepository<StockDetail, Long> 
     Optional<StockDetail> findByStock_Symbol(String symbol);
 
     Optional<StockDetail> findByStock_Id(Long stockId);
+
+    List<StockDetail> findTop20ByOrderByAiRankAsc();
 }

--- a/src/main/java/com/synergyx/trading/repository/StockOhlcvRepository.java
+++ b/src/main/java/com/synergyx/trading/repository/StockOhlcvRepository.java
@@ -43,4 +43,14 @@ public interface StockOhlcvRepository extends JpaRepository<StockOhlcv, Long> {
     // entryAt (포함) 이전의 가장 최근의 종가 조회
     Optional<StockOhlcv> findTop1ByStockIdAndTimestampLessThanEqualOrderByTimestampDesc(Long stockId, LocalDateTime entryAt);
 
+    // ai top 20 - 현재가 조회
+    @Query("""
+                SELECT o FROM StockOhlcv o
+                WHERE o.timestamp = :timestamp
+                AND o.stock.id IN :stockIds
+            """)
+    List<StockOhlcv> findByTimestampAndStockIdIn(
+            @Param("timestamp") LocalDateTime timestamp,
+            @Param("stockIds") List<Long> stockIds
+    );
 }

--- a/src/main/java/com/synergyx/trading/service/stockService/ranking/StockRankingQueryServiceImpl.java
+++ b/src/main/java/com/synergyx/trading/service/stockService/ranking/StockRankingQueryServiceImpl.java
@@ -1,7 +1,5 @@
 package com.synergyx.trading.service.stockService.ranking;
 
-import com.synergyx.trading.apiPayload.code.status.ErrorStatus;
-import com.synergyx.trading.apiPayload.exception.GeneralException;
 import com.synergyx.trading.dto.stockDetail.RankedStockDTO;
 import com.synergyx.trading.model.Stock;
 import com.synergyx.trading.model.StockDetail;
@@ -19,10 +17,8 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static com.synergyx.trading.util.ParsingUtil.toFormattedNumber;
 import static com.synergyx.trading.util.ParsingUtil.toFormattedPercentage;
@@ -100,102 +96,64 @@ public class StockRankingQueryServiceImpl implements StockRankingQueryService {
     }
 
     /**
-     * AI 예측값의 상승폭을 기준으로 상위 20개 종목을 조회합니다.
+     * AI 예측값의 상승률을 기준으로 상위 20개 종목을 조회합니다.
      *
-     * @return AI 예측값의 상승폭 기준 TOP 20 종목 목록
+     * @return AI 예측값의 15일간 평균 상승률 기준 TOP 20 종목 목록
      */
     @Override
     @Transactional(readOnly = true)
     public List<RankedStockDTO> getAiTop20() {
         log.info("[StockRanking] AI 예측 기반 TOP20 랭킹 조회 시작");
 
-        // todo: 임시 데이터
-        List<Long> stockIds = IntStream.rangeClosed(1, 20)
-                .mapToObj(Long::valueOf)
+        // AI 예측 랭킹 상위 20개 (평균 상승률 기준)
+        List<StockDetail> topDetails = stockDetailRepository.findTop20ByOrderByAiRankAsc();
+        if (topDetails.isEmpty()) {
+            log.warn("[StockRanking] AI 예측 랭킹 데이터가 없습니다.");
+            return Collections.emptyList();
+        }
+
+        // 필요한 종목 ID 수집 및 매핑
+        List<Long> stockIds = topDetails.stream()
+                .map(detail -> detail.getStock().getId())
                 .toList();
 
-        // stock 조회
         Map<Long, Stock> stockMap = stockRepository.findAllById(stockIds).stream()
                 .collect(Collectors.toMap(Stock::getId, s -> s));
 
-        List<RankedStockDTO> result = IntStream.rangeClosed(1, 20)
-                .mapToObj(rank -> {
-                    long stockId = rank;
-                    Stock stock = Optional.ofNullable(stockMap.get(stockId))
-                            .orElseThrow(() -> new GeneralException(ErrorStatus.STOCK_NOT_FOUND));
+        // Ohlcv 종가 데이터 가져오기
+        LocalDateTime latestTimestamp = stockOhlcvRepository.findLatestTimestamp();
+        List<StockOhlcv> latestOhlcvs = stockOhlcvRepository.findByTimestampAndStockIdIn(latestTimestamp, stockIds);
+        Map<Long, StockOhlcv> ohlcvMap = latestOhlcvs.stream()
+                .collect(Collectors.toMap(ohlcv -> ohlcv.getStock().getId(), ohlcv -> ohlcv));
+
+        // DTO 변환
+        AtomicInteger rankCounter = new AtomicInteger(1);
+
+        List<RankedStockDTO> rankedList = topDetails.stream()
+                .map(detail -> {
+                    Stock stock = stockMap.get(detail.getStock().getId());
+                    StockOhlcv ohlcv = ohlcvMap.get(detail.getStock().getId());
+
+                    // 현재 종가
+                    String formattedPrice = (ohlcv != null)
+                            ? toFormattedNumber(ohlcv.getClose())
+                            : "N/A";
+
+                    // 예측 평균 상승률
+                    String formattedPredictedIncrease = toFormattedPercentage(detail.getAiAvgIncrease(), 2);
 
                     return RankedStockDTO.builder()
-                            .rank(rank)
-                            .stockId(stockId)
+                            .rank(rankCounter.getAndIncrement())
+                            .stockId(stock.getId())
                             .stockName(stock.getName())
-                            .price(getMockPrice(rank)) // todo: 임시 예측 종가
-                            .changeRate(getMockChangeRate(rank)) // todo: 임시 상승률
+                            .price(formattedPrice)
+                            .changeRate(formattedPredictedIncrease)
                             .imageUrl(stock.getImageUrl())
                             .build();
-                }).toList();
+                })
+                .toList();
 
-//        log.info("[StockRanking] AI 랭킹 조회 완료 - {}개 반환", result.size());
-        return result;
+//        log.info("[StockRanking] AI 예측 기반 TOP20 조회 완료 - {}개 반환", rankedList.size());
+        return rankedList;
     }
-
-    /**
-     * 임시 목데이터 - 예측 종가
-     * todo: delete
-     */
-    private String getMockPrice(int rank) {
-        return switch (rank) {
-            case 1 -> "59,100";
-            case 2 -> "112,000";
-            case 3 -> "74,300";
-            case 4 -> "48,900";
-            case 5 -> "126,000";
-            case 6 -> "191,000";
-            case 7 -> "91,400";
-            case 8 -> "474,000";
-            case 9 -> "513,000";
-            case 10 -> "169,000";
-            case 11 -> "28,500";
-            case 12 -> "41,600";
-            case 13 -> "495,000";
-            case 14 -> "19,600";
-            case 15 -> "144,000";
-            case 16 -> "23,900";
-            case 17 -> "345,000";
-            case 18 -> "151,000";
-            case 19 -> "85,200";
-            case 20 -> "92,300";
-            default -> "0";
-        };
-    }
-
-    /**
-     * 임시 목데이터 - 예측 상승률
-     * todo: delete
-     */
-    private String getMockChangeRate(int rank) {
-        return switch (rank) {
-            case 1 -> "2.25%";
-            case 2 -> "-0.82%";
-            case 3 -> "1.12%";
-            case 4 -> "-1.20%";
-            case 5 -> "0.95%";
-            case 6 -> "3.11%";
-            case 7 -> "2.78%";
-            case 8 -> "-0.65%";
-            case 9 -> "0.85%";
-            case 10 -> "1.02%";
-            case 11 -> "2.00%";
-            case 12 -> "-0.45%";
-            case 13 -> "1.57%";
-            case 14 -> "-1.90%";
-            case 15 -> "0.65%";
-            case 16 -> "1.33%";
-            case 17 -> "0.48%";
-            case 18 -> "-0.95%";
-            case 19 -> "0.75%";
-            case 20 -> "1.18%";
-            default -> "0.00%";
-        };
-    }
-
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
ai top 20 목록 조회 api 에서 임시 데이터 -> 실제 데이터 조회로 수정

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #97

## ⏳ 작업 내용
- stock detail 테이블에 ai_rank, ai_avg_increase 컬럼 추가했습니다.
- 예측값 평균 상승률 기준으로 저장된 순위대로 반환합니다.
  - 상승률, 순위 계산과 저장은 ml 서버 예측 배치에 포함됩니다.
- price: 현재 가격,
- changerate: 예측 상승률을 나타냅니다.

## 📸 스크린샷
<img width="825" height="428" alt="image" src="https://github.com/user-attachments/assets/6ba1330c-6f1b-456b-85dd-41619c9ece86" />


## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * AI 랭킹 기반 Top 20 종목 리스트 제공
  * 각 종목에 최신 시세 기준 현재가와 15일 AI 평균 상승률 표시
  * 랭킹에 따라 오름차순 정렬 및 명확한 순위 표기

* 리팩터링
  * 모의 데이터를 제거하고 실데이터로 전환하여 정확도와 신뢰성 개선
  * 불필요한 예외 흐름을 정리해 동작 일관성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->